### PR TITLE
Skipping circleci build.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,5 @@
 version: 2.1
+
 jobs:
   none:
     docker:
@@ -11,4 +12,4 @@ workflows:
   version: 2
   mainbuild:
     jobs:
-  - none
+      - none

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,14 @@
+version: 2.1
+jobs:
+  none:
+    docker:
+      - image: alpine:3.10
+    steps:
+      - run:
+          command: echo "Skipping. not implemented"
+
+workflows:
+  version: 2
+  mainbuild:
+    jobs:
+  - none


### PR DESCRIPTION
https://github.com/mattermost/mattermost-handbook/pull/25
build is failing with the reason that CircleCI is picking up the project, but no circle ci config is given. This adds an empty circleCI. 