### PR TITLE
Update paid-time-off.md

### DIFF
--- a/operations/workplace/people/working-at-mattermost/paid-time-off.md
+++ b/operations/workplace/people/working-at-mattermost/paid-time-off.md
@@ -18,15 +18,17 @@ Note: If you are taking [Pregnancy](leaves-of-absence/pregnancy-leave.md) or [Pa
 
 ### When you take time-off \(full days only\) please do the following:
 
-1. Add your time-off to the [Mattermost Time-Off Calendar](https://calendar.google.com/calendar?cid=bWF0dGVybW9zdC5jb21fbWczbnVsZ2Y2ZTcwZTUwb2hscTJycmtjbmNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).   
+1. Add your time-off to the [Mattermost Time Away Calendar](https://calendar.google.com/calendar?cid=bWF0dGVybW9zdC5jb21fbWczbnVsZ2Y2ZTcwZTUwb2hscTJycmtjbmNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).   
 2. People Managers - ensure your teams understand your [**vacation ready**](https://handbook.mattermost.com/operations/operations#fy20-mlt-vpmom) **expectations**. 
 3. If you are staffed in Canada, Germany or UK, we are required to track vacation up to the statutory amount. Any time off after that does not need to be recorded. [HR](mailto:hr@mattermost.com) will share an individual document tracker. 
 4. Enjoy your time off! 
 
-### Where to go to see who's on PTO:
+**Note** The itnent of the Time Away Calendar is to maintain asynchronous communication. Please use the calendar to note any full days that you may not be available. This may include conferences, meet-ups and team off-sites. 
+
+### Where to go to see who's out:
 
 * [Stand-up channel](https://community.mattermost.com/private-core/channels/stand-up) 
-* [Mattermost Time Off calendar](https://calendar.google.com/calendar/embed?src=mattermost.com_mg3nulgf6e70e50ohlq2rrkcnc%40group.calendar.google.com&ctz=America%2FLos_Angeles)
+* [Mattermost Time Away calendar](https://calendar.google.com/calendar/embed?src=mattermost.com_mg3nulgf6e70e50ohlq2rrkcnc%40group.calendar.google.com&ctz=America%2FLos_Angeles)
 
 ### Common Time-Off Questions
 

--- a/operations/workplace/people/working-at-mattermost/paid-time-off.md
+++ b/operations/workplace/people/working-at-mattermost/paid-time-off.md
@@ -23,7 +23,7 @@ Note: If you are taking [Pregnancy](leaves-of-absence/pregnancy-leave.md) or [Pa
 3. If you are staffed in Canada, Germany or UK, we are required to track vacation up to the statutory amount. Any time off after that does not need to be recorded. [HR](mailto:hr@mattermost.com) will share an individual document tracker. 
 4. Enjoy your time off! 
 
-**Note** The itnent of the Time Away Calendar is to maintain asynchronous communication. Please use the calendar to note any full days that you may not be available. This may include conferences, meet-ups and team off-sites. 
+**Note** The intent of the Time Away Calendar is to maintain asynchronous communication. Please use the calendar to note any full days that you may not be available. This may include conferences, meet-ups and team off-sites. 
 
 ### Where to go to see who's out:
 


### PR DESCRIPTION
Changed the calendar name to "Time Away" and added a note that this cal can be used for full days away, including time for off-sites, conferences or meet-ups.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
