### PR TITLE
broken link - vacation-ready

### DIFF
--- a/operations/workplace/people/working-at-mattermost/paid-time-off.md
+++ b/operations/workplace/people/working-at-mattermost/paid-time-off.md
@@ -19,7 +19,7 @@ Note: If you are taking [Pregnancy](leaves-of-absence/pregnancy-leave.md) or [Pa
 ### When you take time-off \(full days only\) please do the following:
 
 1. Add your time-off to the [Mattermost Time Away Calendar](https://calendar.google.com/calendar?cid=bWF0dGVybW9zdC5jb21fbWczbnVsZ2Y2ZTcwZTUwb2hscTJycmtjbmNAZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ).   
-2. People Managers - ensure your teams understand your [**vacation ready**](https://handbook.mattermost.com/operations/operations#fy20-mlt-vpmom) **expectations**. 
+2. People Managers - ensure your teams understand your vacation-ready expectations. 
 3. If you are staffed in Canada, Germany or UK, we are required to track vacation up to the statutory amount. Any time off after that does not need to be recorded. [HR](mailto:hr@mattermost.com) will share an individual document tracker. 
 4. Enjoy your time off! 
 


### PR DESCRIPTION
Proposing we add to [list of terms](https://handbook.mattermost.com/company/about-mattermost/list-of-terms): Vacation-ready - A team and process is ready for a key member to go on vacation, or spend time away from work.  

Then update link here to link to the definition,
