### PR TITLE
Update product-technical-writing-team-handbook.md

### DIFF
--- a/operations/research-and-development/product/product-technical-writing-team-handbook.md
+++ b/operations/research-and-development/product/product-technical-writing-team-handbook.md
@@ -108,8 +108,6 @@ If your change requires dev review add the developer/s you've been working with 
 
 Requests for documentation can be made within [community.mattermost.com](https://community.mattermost.com), using the Doc Up plugin embedded in the post menu.
 
-![Access the Doc Up plugin by hovering over a message and clicking the &quot;...&quot; menu.](https://github.com/mattermost/mattermost-handbook/tree/c599ecb3099db323d84d21139fcf298c360cee64/.gitbook/assets/image%20%2852%29.png)
-
 When you select Doc Up and choose **Admin** as the issue type, an issue is generated in the GitHub docs repo, and added to the issues list. An update is listed in the Documentation channel, with the issue link.
 
 You can also select **Developer** or **Company Handbook** to direct the Doc Up request to the appropriate repo.
@@ -198,4 +196,3 @@ If you have any questions, you can post them in the [Documentation](https://comm
 Most, if not all, contributions to the Mattermost project have a documentation impact. As part of the development and submission process, it’s recommended that the relevant documentation be updated \(or created\) and included in the PR. This provides consistency and accuracy in communicating the changes/new feature and cuts down on having multiple issues and PRs for related documentation. The documentation can be as detailed or concise as deemed necessary - consider it an MVP which can be refined at a later stage.
 
 When submitting your PR, please include the **Editor Review** label and add @amyblais or @justinegeffen in GitHub as an approver.
-


### PR DESCRIPTION
Removing broken Doc Up image until https://github.com/mattermost/mattermost-handbook/pull/155 is merged.
