### PR TITLE
Move release process docs to handbook

### DIFF
--- a/operations/research-and-development/product/release-process/README.md
+++ b/operations/research-and-development/product/release-process/README.md
@@ -1,0 +1,1 @@
+Learn more about our release planning strategy and processes.

--- a/operations/research-and-development/product/release-process/bug-fix-release.md
+++ b/operations/research-and-development/product/release-process/bug-fix-release.md
@@ -1,0 +1,289 @@
+# Quality Release Process
+
+## Release Timeline
+
+Notes:
+- All cut-off dates are based on 10am ([San Francisco Time](https://everytimezone.com/)) on the day stated.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [the listed statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
+
+### A. (Code complete date of previous release) Beginning of Release
+
+Pre-work for the current release begins at the code complete date of the previous release. See "Code Complete" section below for details.
+
+### B. (T-minus 20 working days) Bug Fixing
+
+1. **(Team) Daily Release Update Meeting (10:00am San Francisco time)**: 
+    - Begin daily triage of tickets
+        - Also start to triage tickets in the backlog
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Schedule a meeting with PMs and QAs to discuss upcoming features in the next feature release
+        - Also review with PMs any Help Wanted campaigns QAs should be aware of
+    - After release branches are cut:
+        - Go through and add "Cherry-pick Approved" labels to all release PRs and ask devs to cherry-pick already merged PRs
+        - Ask dev to cut an RN build for QA testing
+    - Draft Changelog in a WIP PR with updates for known issues, compatibility updates for deprecated features, config.json, [database changes](https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/upgrade.go), [API changes](https://github.com/mattermost/mattermost-server/commits/master/model/client.go), and [WebSocket event changes](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_message.go#L13); [see example](http://docs.mattermost.com/administration/changelog.html#compatibility)
+      - Note the type of release and add a link to release doc that defines the type (https://docs.mattermost.com/process/release-faq.html#release-overview)
+    - Review [supported OS versions](https://docs.mattermost.com/install/requirements.html#server-software) and review that [software requirements](https://docs.mattermost.com/install/requirements.html#software-requirements) are up-to-date based on [these step-by-step guidelines](https://docs.mattermost.com/process/software-requirements.html)
+    - Start posting a daily list of open bugs and PRs (posted until zero bugs or day of release)
+    - Post a reminder in the French Localization channel about the due date for translations, similar to this [example](https://community.mattermost.com/core/pl/7wqx4zehotgu7efhmbz51mxfqa). Follow that translations are prioritized at https://translate.mattermost.com/projects/mattermost/
+3. Dev:
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the pull request queue marked for the current release
+      - After the cut-off, any PRs that include significant code changes, require approval of the release manager before merging
+    
+### C. (T-minus 19 working days) Release Bug Testing
+
+1. QA:
+    - Prioritize testing PRs and resolved tickets for this release
+    - Ensure that all bugs are also properly tested on mobile apps
+    - Prioritize updating release tests in test management and automated tests
+
+### D. (T-minus 15 working days) Judgment Day
+
+1. **(Team) Judgment Day Meeting (10:00am San Francisco time)**: 
+    - Continue triaging tickets
+    - Discuss worst bug currently on the release branch
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Queue a list of MVP candidates in alphabetical order to the MVP Discussion channel [See example](https://community.mattermost.com/core/pl/iau7cw7wzfdxze9ea7jr4bu3ay)
+    - Create meta issue for release in GitHub (see [example](https://github.com/mattermost/mattermost-server/issues/3702))
+    - Confirm date of marketing announcement for the release date with Marketing, and update release channel header if needed
+      - If release day falls on a Friday, the blog post goes out on the Friday and the emailed newsletter goes out the following Tuesday.
+    - Post a reminder to devs in the Release Discussion channel of the the code complete date with a list of open bugs and PRs [see example](https://community.mattermost.com/core/pl/coggyys9atg7fqyam81q3gkmoo)
+    - Ask PMs and dev leads if there are any notable breaking changes or deprecated features in the release
+    - Update [Upgrade Guide](https://docs.mattermost.com/administration/important-upgrade-notes.html) with any special notes for upgrading to the new version
+    - Ask PMs to review the Jira tickets remaining in the current release fix version and push those that won't make it to the next fix version
+    - Ask PMs and Tech writer to complete release documentation by T-2 deadline. [Example request](https://community.mattermost.com/core/pl/w4oobh4zpigsfbqskx5ix5jgxo)
+3. Leads:
+    - Finalize roadmap for next release, and identify planned marketing bullet points
+4. Marketing:
+    - Prepare bullet points and release headline for release announcement. Release Manager to review the outline (benefits and order of major features) with PMs before sending to Justin to work on. [Refer to the process here](https://handbook.mattermost.com/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements)
+    - Start drafting blog post, tweet, and email for the release announcement
+    
+### E. (T-minus 12 working days) Code Complete
+
+Review the [Release Features & Bug Guidelines](https://docs.google.com/document/d/1QxB_A1qkEJBKAvQpRa7JiSQLZhwg6HAEajNRNa7ldGg/edit)
+
+1. **(Team) Code Complete Meeting (10:00am San Francisco time)**:
+    - Last check of tickets that need to be merged before RC1
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Submit `NOTICE.txt` PRs for any new libraries added from dev, and ensure they are cherry-picked to quality release branch
+    - If there are any breaking compatibility changes in the release, open an issue in the [GitLab Omnibus](https://gitlab.com/gitlab-org/omnibus-gitlab) to make sure GitLab is aware. Post a link to the issue in the Release Discussion channel
+    - Ask UX to [create a "Hero" screenshot as the splash image for the release blog post](https://handbook.mattermost.com/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements#one-great-screenshot-a-month)
+3. Dev:
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the pull request queue marked for the current release
+4. QA:
+    - Identify any new teammates who will be joining release testing, send them an intro to the testing process and timeframe, send them the [hardware/software survey](https://drive.google.com/open?id=1IUiNO2S5fgWVn-Y_cyouxheukqKyGQC0_2UX64Ejwk8)
+    - Set up DM/GM channels in preparation for testing auto-closing after 7 days
+
+### F. (T-minus 11 working days) Release Candidate Cut
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Generate a list of contributors for Changelog
+    - Ask martin.kraft to provide a list of Database changes, API changes, WebSocket event changes, and config.json setting changes for Changelog. [See example request](https://github.com/mattermost/docs/pull/3398#issuecomment-593411501)
+2. Logistics @hanna.park:
+    - Mail out contributor and security researcher mugs
+      - Space out the ordering of mugs over the next three weeks to prevent mistakes being made by the supplier (e.g., If there are 12 contributors to order mugs for, place an order every 2nd or 3rd day over the next three weeks)
+    - Update [Team](https://www.mattermost.org/team/) page with new contributors
+3. QA:
+    - Confirm up to date with testing PRs and resolved tickets
+    - Confirm up to date with test updates and known issues in release test management and automated tests
+    - Assign release testing areas to team members
+    - After RC1 is cut: Update test server invite links in Release Testing instructions
+    - After RC1 is cut: Run automated regression tests
+4. Build:
+    - Review all `TODO` notes, including one for uncommenting upgrade code
+    - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged
+    - Update Redux before each RC and Final build
+    - Update package version in [Mattermost DockerFile](https://github.com/mattermost/mattermost-server/blob/master/build/Dockerfile#L7)
+    - Master is tagged and branched and `Release Candidate 1` is cut (e.g., 3.5.0-RC1) according to the Release Candidate Checklist in ``mattermost/process``
+    - After branching, the database version in `sql_upgrade.go` on master is set to the next scheduled release version (e.g., 3.6.0)
+
+### G. (T-minus 10 working days) Release Candidate Testing
+
+1. **(Team) Daily Release Update Meeting**
+    - Triage Jira tickets
+    - Decide when to cut next RC
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Update the GitHub meta issue:
+       - Include a link to the Changelog on the documentation branch
+       - Update download links and testing server links to the latest RCs
+    - After build is cut, tweet announcement that RC1 is ready (see [example](https://community.mattermost.com/core/pl/tefx1ijyz7bs8mabuxmpq9f7pw))
+    - Post list of tickets to be fixed to the Release Discussion channel ([see example](https://community.mattermost.com/core/pl/65k77x3bnigw5f9ffohfxonnfy))
+    - Cut next Release Candidate [using this process](https://github.com/mattermost/internal-docs/blob/63dcb6d0ff5d20ab9310466065dc15799b12708c/site/content/infra/release-tasks.md) and check CI servers running on release branch
+3. QA:
+    - Update Release Discussion header with links to RC instances and testing spreadsheet ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.ghe4vz9zd1v))
+    - Post release testing instructions to Release Discussion channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.u28aar2hx7hg))
+    - Post reminders in Announcements channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.pirw51cwsja5)) and Customer Support channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.ke0fh13gidni))
+    - DM reminders if needed to team members who are not QA or devs, or who are new to release testing
+4. Logistics @hanna.park:
+    - Generate an E20 5000 seat test licence and email to Lindy for release testing
+5. Dev:
+    - Make PRs for bug fixes to the release branch
+    - Review PRs made from release branch and cherry-pick changes into the release branch
+    - Run daily automated upgrade tests to avoid catching upgrade bugs late
+6. Marketing:
+    - Finish draft of blog post for mattermost.com and all art work (screenshots and GIFs) used for the blog post
+        - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
+    - Send blog post for Release Manager and PMs to review
+
+### H. (T-minus 9 working days) Release Candidate Testing Finished
+
+1. **(Team) Daily Release Update Meeting**
+    - Confirm testing assigned in the Release Testing spreadsheet is complete 
+    - Continue to triage Jira tickets
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Verify that the final translations PR for the release is submitted
+    - Update https://docs.mattermost.com/administration/open-source-components.html
+    - Confirm Changelog reflects any changes since it was merged (including known issues and contributors from all repositories)
+      - Verify that translators and new integration contributors were added
+      - Verify that Open Source Components changes were added
+      - Update **Known Issues** section with any significant issues that were found and not fixed for the final release
+    - Find [www-gitlab-com merge request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests?scope=all&utf8=%E2%9C%93&state=opened&label_name%5B%5D=blog%20post&label_name%5B%5D=release) for latest GitLab release blog post and make request for adding GitLab Mattermost update (see [example request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests/2910#note_14096885), [example update](https://about.gitlab.com/2016/07/22/gitlab-8-10-released/#gitlab-mattermost-32)). Post to Release Discussion channel with link to request.
+3. Marketing:
+    - Send blog post for mattermost.com and all related art work for marketing lead to review
+4. QA:
+    - Midday: Post reminders about testing, at-mentioning team members whose tests are not yet complete
+    - Find QA or other teammates to help finish unfinished tests if needed
+    - End of day or next morning: Verify all release tests are finished, bring any concerns to Triage / Release meeting
+    - Go through all tabs of testing spreadsheet and verify all comments and questions have been filed in Jira as needed
+    
+### I. (T-minus 5 working days) Code Freeze
+Day after which only **S1 regressions** should be fixed (crashes, security vulnerabilities) and no other code changes should be committed. Exceptions can be made by the Release Manager during triage on a case-by-case basis. Review the [Bug Severity Guidelines](https://docs.mattermost.com/process/bug-severity-guidelines.html).
+
+1. **(Team) Daily Release Update Meeting**
+    - Continue to triage Jira tickets
+    - If no blocking issues are found, PM, Dev, and QA sign off on the release and begin final smoke tests
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+3. QA:
+    - Verify all Jira tickets other than newly-filed bugs have been tested, verified, and closed
+    - As bug fixes are merged and RCs are cut, verify fixes on new RCs, and post in Release Channel after testing
+    - After all tickets are verified and closed, run smoke tests on webapp/server, desktop app, and RN apps as appropriate
+5. Docs:
+    - Submit Changelog PR for team review
+    - Submit any remaining documentation PRs for product updates in the release
+    - Check that a redirect page has been set up in mattermost.com for any links added to the System Console
+    - Submit documentation for [API changes](https://github.com/mattermost/mattermost-server/commits/master/model/client.go) and [WebSocket event changes](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_message.go#L13) to  API documentation
+    - Confirm changes to `config.json` in compatibility section of Changelog are written back to [settings documentation](https://docs.mattermost.com/administration/config-settings.html#configuration-settings)
+    - Confirm all new diagnostics are documented in the telemetry docs (https://docs.mattermost.com/administration/telemetry.html)
+
+### J. (T-minus 2 working days) Release Build Cut
+
+The final release is cut - RC cuts and bug fixes should be completed by this date. Only urgent and critical issues are considered for fixing.
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Work with a developer to submit GitLab MR [following this process](https://docs.mattermost.com/process/gitlab-process.html#merge-requests) and [test the upgrade](https://docs.google.com/document/d/1mbeu2XXwCpbz3qz7y_6yDIYBToyY2nW0NFZq9Gdei1E/edit#heading=h.ncq9ltn04isg) once the GitLab MR is merged and included in their RC.
+    - Close GitHub meta ticket for the release
+    - Add the download links and SHA-256 hash [upgrade guide](http://docs.mattermost.com/administration/upgrade.html#version-archive)
+    - Merge Changelog PR after review is complete
+      - If there is a security fix, confirm the Changelog recommends upgrade, with a note mentioning the security level and thanking the security researcher (security process doc for example)
+    - Update the [Mattermost server download page](https://www.mattermost.org/download/) with the links to the EE and TE bits
+      - Test the download links before and after updating the page
+    - Check security tickets and confirm disclosure text
+    - Check the security researcher was added to the [Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/) page
+    - Confirm link to security updates appears in blog post if there are security updates in this release, with a note thanking the security researcher
+    - Update [deprecated feature list](https://about.mattermost.com/deprecated-features/) in mattermost.com with new and scheduled deprecations
+    - Draft [Mattermost Security Updates](http://about.mattermost.com/security-updates/), but do not post until 30 days after official release. 
+      - Add a placeholder text saying "Details on the security update will be posted here on X date, as per our Responsible Disclosure Policy"
+2. QA:
+    - Verify all PRs and tickets for the release have been tested / closed
+    - Verify smoke tests on webapp/server, desktop app, and RN apps all passed
+    - Post QA approval in Release Discussion channel
+3. Build:
+    - Update Redux before each RC and Final build
+    - Tags a new release (e.g., 1.1.0) and runs an official build which should be essentially identical to the last RC
+    - Posts SHA key, md5 sum, and GPG signatures of the final build to release channel
+    - Post in Release Discussion with links to the Enterprise Edition and Team Edition sections
+4. Dev:
+    - Verify the hashes (SHA-1, SHA-256, and md5) and GPG signatures are correct for both Enterprise Edition and Team Edition.
+    - Test upgrade from previous version to current version, following the [Upgrade Guide](https://docs.mattermost.com/administration/upgrade.html#upgrade-guide) with database upgrades on both MySQL and Postgres
+    - Test upgrade from Team Edition to Enterprise edition based on the [Upgrade Guide](https://docs.mattermost.com/administration/upgrade.html#upgrade-team-edition-to-enterprise-edition)
+    - Test fresh install of current version, following the [Install Guide](https://docs.mattermost.com/guides/administrator.html#installing-mattermost)
+    - Review any changes made to install guides, and test if necessary
+    - Ensure [Security Policies](https://docs.mattermost.com/process/security.html) page has been updated
+    - Update dependancies after release branch is cut in `mattermost-server`, `mattermost-webapp`, `desktop`, `mattermost-mobile`, and `mattermost-redux`
+5. Logistics @hanna.park:
+    - Order the release MVP winner's coaster
+6. Docs:
+    - Finalize docs
+      - If reviews are not complete, hold a 30 minute doc review meeting with PMs and anyone else who has changed or reviewed docs this release and wants to join
+      - Merge the docs release branch to master and verify all changes on docs.mattermost.com once the build is up
+      - Submit a correction PR for any incorrect formatting or other errors missed during the initial review
+7. Marketing:
+    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
+      - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](https://eepurl.com/cAl5Rv)
+    - Finalize blog post for mattermost.com, test on mobile view, and set timer for 08:00 PST on the day of release
+    - Add links to [Admin guide](https://docs.mattermost.com/guides/administrator.html) in the release blog post where needed
+
+### K. (T-minus 0 working days) Release Day
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Schedule a release retrospective meeting, to be held within five days of the release
+    - Update Integrations Directory on the [Mattermost Apps and Integrations](https://integrations.mattermost.com/) page
+    - Prepare and post [release metrics](https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oVw-M/edit#gid=825551144)
+    - Post an MVP winner announcement in the [Contributors channel](https://community.mattermost.com/core/channels/tickets)
+    - Update [MVP page](https://www.mattermost.org/mvp/) with the most valued professional of the release
+    - Add new release fix versions in Jira for the next few releases
+    - Post key dates for the next release in the Release Discussion channel and remove links to RC candidates and testing spreadsheet from the header
+        - Make sure that statutory holidays for Canada and US are accounted for in the release dates
+    - Close the release in Jira both for webapp and mobile ([releases page](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page))
+    - For the next release, create the following team meetings. If they conflict with existing meetings, check with meeting owner to reschedule or reschedule the release meeting
+      - Bug Bash Meeting on the week after Code Complete at 10:00am San Francisco time
+      - Feature Complete Meeting on T-20 at 10:00am San Francisco time
+      - Judgment Day Meeting on T-15 at 10:00am San Francisco time
+      - Code Complete Meeting on T-14 at 10:00am San Francisco time
+      - Release Triage and Update Meeting each weekday starting at T-15 and ending at T-2 at 9:30am San Francisco time for PM, QA and release dev.
+    - Prepare tickets for the next release, with a corresponding vX.X prefix, and put the tickets in the appropriate sprints as follows:
+        - The week RC is cut:
+            - [RC Build Testing for core team](https://mattermost.atlassian.net/browse/PLT-2208)
+        - The week RC is cut:
+            - [Loadtest x.x release candidate compared to x.x release](https://mattermost.atlassian.net/browse/MM-12532)
+        - The week RC is cut (for GitLab dev owner):
+            - Test RC1 with the latest GitLab build during release testing cycle
+        - Release week (for dependancies owner)
+            - Upgrade dependancies for webapp, server, and Redux
+        - Week after release (for GitLab dev owner)
+            - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
+    - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
+    - Contact owners of [community installers](https://www.mattermost.org/installation/) or submit PRs to update install version number
+      - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a).
+      - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/ist-dsi/mattermost-cookbook/issues/22).
+      - For Yunohost, open a new pull request to update the version. See [example](https://github.com/YunoHost-Apps/mattermost_ynh/pull/103).
+2. Docs:
+    - Create a new branch on docs for the next release - `vX.X-documentation`
+        - Submit a PR for changelog against the `vX.X-documentation` branch and add a `Work in Progress` label for it
+        - Submit a PR to change version number in `docs/source/conf.py` against the `vX.X-documentation` branch
+3. Build:
+    - Cut release branches for the next feature release
+        - Ensure `community-release` server is on the feature release branch
+    - Put CI servers and translation server back onto master, and post in Private Developers channel once done
+    - Ensure https://community.mattermost.com is on the most recently released version and that https://prev.test.mattermost.com is on the most recently released bug fix release
+4. Marketing:
+    - Turn on CrazyEgg for blog post page
+    - Confirm marketing has been posted (animated GIFs, screenshots, mail announcement, tweets, blog posts)
+    - Update @mattermosthq Twitter profile with the next release date
+    - Prepare retweet of GitLab release tweet ([see example here](https://community.mattermost.com/core/pl/k7wchwj5mtrhucj6don96yx3sc))
+5. QA:
+    - Merge any updates made to Selenium tests during release testing
+    - Update RN server URLs to Rainforest
+
+### L. (T-plus 30 days) Update Mattermost Security Page
+
+1. Release Manager:
+    - Post [Mattermost Security Updates](https://about.mattermost.com/security-updates/) after reviewing with security lead
+      - If a dot release is shipping with security fixes, do not post new details until T-plus 10 working days from the dot release ship date

--- a/operations/research-and-development/product/release-process/bug-fix-release.md
+++ b/operations/research-and-development/product/release-process/bug-fix-release.md
@@ -259,6 +259,8 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - Upgrade dependancies for webapp, server, and Redux
         - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
+        - The week of code complete:
+            - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](https://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a).

--- a/operations/research-and-development/product/release-process/dot-release.md
+++ b/operations/research-and-development/product/release-process/dot-release.md
@@ -1,0 +1,56 @@
+# Dot Release Process
+
+If a bug fix release is required, run through the below steps.
+
+## Release Timeline
+
+Notes:
+- All cut-off dates are based on 10am ([San Francisco Time](http://everytimezone.com/)) on the day stated.
+- T-minus counts are measured in "working days" (weekdays other than major holidays concurrent in US and Canada) prior to release day.
+
+### A. (T-minus 4 working days) Code complete
+
+1. Release Manager:
+    - Once the list of bugs to be fixed is finalized, post this checklist in Release Checklist channel
+    - Notify community about upcoming dot release through a Twitter announcement and in changelog with links to approved fixes and a date tagged as "TBD"
+    - Open an issue in the [GitLab Omnibus](https://gitlab.com/gitlab-org/omnibus-gitlab) mentioning a dot release is coming. [See example](https://gitlab.com/gitlab-org/omnibus-gitlab/issues/3099)
+    - Work with a developer to submit GitLab MR [following this process](https://docs.mattermost.com/process/gitlab-process.html#merge-requests) and [test the upgrade](https://docs.google.com/document/d/1mbeu2XXwCpbz3qz7y_6yDIYBToyY2nW0NFZq9Gdei1E/edit#heading=h.ncq9ltn04isg) once the GitLab MR is merged and included in their RC.
+      - Open a ticket to [submit Gitlab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-10365)
+    - Make a post in Announcements channel announcing the dot release to the rest of the team with links to approved tickets and include a link to the ticket to submit the GitLab MR
+2. Dev:
+    - PRs for hotfixes are made to release branch
+    - Review PRs made from release branch and merge changes into the release branch as required and merge the release branch back into master once per day
+
+### B. (T-minus 3 working days) Release Candidate Cut
+
+1. Build:
+    - Verify with Release Manager before cutting any new dot release RCs (approved fixes should be merged)
+    
+### C. (T-minus 2 working days) Release Candidate Testing
+
+1. QA:
+    - If the dot release takes place during a regular release, update ``prev.test.mattermost.com`` to dot-release RCs for the previous release and keep ``rc.test.mattermost.com`` on the latest regular release version
+    - Test the new RC to verify fixes merged to the release branch work
+    - Post in Release Discussion channel after testing
+
+### D. (T-minus 0 working days) Release Build Cut
+
+Once bug fix release is ready to cut:
+
+1. Dev:
+    - Tag a new release (e.g. 1.1.1) and run an official build
+    - Verify hashes and GPG signatures are correct, once build is cut
+    - Delete RCs after final version is shipped
+2. Release Manager:
+    - Merge the Changelog PR with notes on patch releases (see [example entry](https://docs.mattermost.com/administration/changelog.html#release-v3-5.1))
+    - Update the [version archive](https://docs.mattermost.com/administration/version-archive.html)
+    - Update [Mattermost server download page](https://mattermost.com/download) with the links to the EE and TE bits
+      - Test the download links before and after updating the page
+    - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
+    - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
+      - For Puppet, Heroku and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/5eh8fw3jaiyzzqoc6nfwfaioya).
+      - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/ist-dsi/mattermost-cookbook/issues/48).
+      - For Yunohost, open a new pull request to update the version. See [example](https://github.com/YunoHost-Apps/mattermost_ynh/pull/143).
+3. Marketing:
+    - Prepare [blog post](https://about.mattermost.com/releases/mattermost-4-10/) for mattermost.com and [Twitter announcement](https://twitter.com/mattermosthq/status/827193482578112512), and send for marketing lead to review. Once reviewed, schedule for 08:00 PST on the day after dot release
+    

--- a/operations/research-and-development/product/release-process/feature-release.md
+++ b/operations/research-and-development/product/release-process/feature-release.md
@@ -299,6 +299,8 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - Upgrade dependancies for webapp, server, and Redux
        - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
+       - The week of code complete:
+            - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a)

--- a/operations/research-and-development/product/release-process/feature-release.md
+++ b/operations/research-and-development/product/release-process/feature-release.md
@@ -1,0 +1,329 @@
+# Feature Release Process
+
+Mattermost core team works on a monthly release process, with a new version shipping on the 16th of each month in [binary form](http://docs.mattermost.com/administration/upgrade.html#mattermost-team-edition). 
+
+This document outlines the development process for the Mattermost core team, which draws from what we find works best for us from Agile, Scrum, and Software Development Lifecycle approaches.
+
+Recommended pre-reading:
+
+- [Mattermost Software Development Process training materials](https://docs.mattermost.com/process/training.html#software-development-process)
+- [Mattermost Security Practices training](https://docs.mattermost.com/process/training.html#system-security) (particularly NIST standards)
+
+## Release Timeline
+
+Notes:
+- All cut-off dates are based on 10am ([San Francisco Time](http://everytimezone.com/)) on the day stated.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [the listed statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
+
+### A. (Code complete date of previous release) Beginning of Release
+
+Pre-work for the current release begins at the code complete date of the previous release. See "Code Complete" section below for details.
+
+### B. (T-minus 23 working days) Cut-off for Submitting Features
+
+No pull requests for major features should be **submitted** to the current release after this date. In special cases, exceptions can be made by the Release Manager. 
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Follow that feature PR reviews are prioritized and post a list of outstanding feature PRs in the [Release Discussion](https://community.mattermost.com/core/channels/release-discussion) channel
+    - Confirm with PMs that each Enterprise feature is in the correct [pricing SKU](https://about.mattermost.com/pricing/)
+    - Review any features that are currently in beta and confirm with PMs if there are any to be promoted
+
+### C. (T-minus 20 working days) Feature Complete
+
+No pull requests for major features should be **merged** to the current release after this date. In special cases, exceptions can be made by the Release Manager.
+
+1. **(Team) Major Feature Complete Meeting (10:00am San Francisco time)**:
+    - Review status of remaining feature PRs to be merged
+    - Begin daily triage of tickets
+        - Also start to triage tickets in the backlog
+2. Release Manager:
+    - Post this checklist in the [Release Checklist](https://community.mattermost.com/core/channels/release-checklist) channel
+    - Verify all items in the last posted release checklist are complete
+    - After release branches are cut, ask dev to cut an RN build
+    - Queue a list of MVP candidates in alphabetical order to the MVP Discussion channel [See example](https://community.mattermost.com/core/pl/3its7ifbw7dh58obpasdszf1mr)
+    - Draft Changelog in a WIP PR with updates for highlights, feature additions, known issues, compatibility updates for deprecated features, config.json, [database changes](https://github.com/mattermost/mattermost-server/blob/master/store/sqlstore/upgrade.go), [API changes](https://github.com/mattermost/mattermost-server/commits/master/model/client.go), and [WebSocket event changes](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_message.go#L13); [see example](http://docs.mattermost.com/administration/changelog.html#compatibility)
+      - Note the type of release and add a link to release doc that defines the type (https://docs.mattermost.com/process/release-faq.html#release-overview)
+    - Review [supported OS versions](https://docs.mattermost.com/install/requirements.html#server-software) and review that [software requirements](https://docs.mattermost.com/install/requirements.html#software-requirements) are up-to-date based on [these step-by-step guidelines](https://docs.mattermost.com/process/software-requirements.html)
+    - Ask PMs if there are any notable breaking changes or deprecated features in the release
+    - Update [Upgrade Guide](https://docs.mattermost.com/administration/important-upgrade-notes.html) with any special notes for upgrading to the new version
+    - Start posting a daily list of open and submitted bugs and PRs (posted until zero bugs or day of release)
+    - Post a reminder in the French Localization channel about the due date for translations, similar to this [example](https://community.mattermost.com/core/pl/7wqx4zehotgu7efhmbz51mxfqa)
+        - Follow that translations are prioritized at https://translate.mattermost.com/projects/mattermost/
+3. Dev:
+    - Cut release branch both for server and mobile
+        - Merge database upgrade before cutting the branch
+        - Point translation server and CI servers to the release branch after cutting
+        - Cut an RN build for the next release
+        - Update https://prev.test.mattermost.com to the previous release version
+    - Ensure `community-release` is on the feature branch
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the [pull request queue](https://github.com/mattermost/mattermost-server/pulls) marked for the current release
+      - After the cut-off, any PRs that include significant code changes require approval of the Release Manager before merging
+4. Marketing:
+    - Prepare bullet points and release headline for release announcement. Release Manager to review the outline (benefits and order of major features) with PMs before sending to Justin to work on. [Refer to the process here](https://handbook.mattermost.com/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements)
+    
+### D. (T-minus 19 working days) Feature Testing
+
+1. QA:
+    - Prioritize testing PRs and resolved tickets for this release
+    - Ensure that new features are also properly tested on mobile apps
+    - Prioritize updating release tests in test management and automated tests
+
+### E. (T-minus 15 working days) Judgment Day
+
+Day when Leads and PMs decide which major features are included in the release, and which are postponed.
+
+1. **(Team) Judgment Day Meeting (10:00am San Francisco time)**: 
+    - Discuss worst bug on the feature branch
+    - Finalize which major features will be in or out for the release
+        - Discuss reverting feature(s) if five or more bugs found
+2. Release Manager:
+    - Post this checklist in [Release Checklist](https://community.mattermost.com/core/channels/release-checklist) channel
+    - Verify all items in the last posted release checklist are complete
+    - Update Changelog PR based on what's in/out of the release
+    - Create meta issue for release in GitHub (see [example](https://github.com/mattermost/mattermost-server/issues/3702))
+    - Confirm date of marketing announcement for the release date with Marketing, and update Release Channel header if needed
+      - If release day falls on a Friday, the blog post goes out on the Friday and the emailed newsletter goes out the following Tuesday
+    - Post a reminder to devs in the Release Discussion channel of the the code complete date with the list of open and submitted bugs and PRs [see example](https://community.mattermost.com/core/pl/coggyys9atg7fqyam81q3gkmoo)
+    - Ask PMs to review the Jira tickets remaining in the current release fix version and push those that won't make it to the next fix version
+    - Ask PMs and Tech writer to complete release documentation by T-2 deadline. [Example request](https://community.mattermost.com/core/pl/w4oobh4zpigsfbqskx5ix5jgxo)
+3. Leads:
+    - Finalize roadmap for next release, and identify planned marketing bullet points
+4. Marketing:
+    - Start drafting blog post, tweet, and email for the release announcement
+    
+### F. (T-minus 14 working days) Code Complete
+
+**Stabilization** period begins when all features for release have been committed. During this period, only **bugs** can be committed to the release branch. Non-bug pull requests are tagged for next version. Exceptions can be made by the Release Manager during triage. Review the [Release Features & Bugs Quality Gate Guidelines](https://docs.google.com/document/d/1QxB_A1qkEJBKAvQpRa7JiSQLZhwg6HAEajNRNa7ldGg/edit)
+
+1. **(Team) Code Complete Meeting (10:00am San Francisco time)**:
+    - Last check of tickets that need to be merged before RC1
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Submit `NOTICE.txt` PRs for any new libraries added from dev, and ensure they are cherry-picked to feature release branch
+    - If there are any breaking compatibility changes in the release, open an issue in the [GitLab Omnibus](https://gitlab.com/gitlab-org/omnibus-gitlab) to make sure GitLab is aware. Post a link to the issue in the Release Discussion channel
+3. Dev:
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the [pull request queue](https://github.com/mattermost/mattermost-server/pulls) marked for the current release
+4. QA:
+    - Identify any new teammates who will be joining release testing, send them an intro to the testing process and timeframe, send them the [hardware/software survey](https://drive.google.com/open?id=1IUiNO2S5fgWVn-Y_cyouxheukqKyGQC0_2UX64Ejwk8)
+    - Set up DM/GM channels in preparation for testing auto-closing after 7 days
+
+### G. (T-minus 9 working days) Release Candidate Cut
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Cut next Release Candidate [using this process](https://github.com/mattermost/internal-docs/blob/63dcb6d0ff5d20ab9310466065dc15799b12708c/site/content/infra/release-tasks.md) and check CI servers running on release branch
+    - Generate a list of contributors for Changelog
+2. Logistics @hanna.park:
+    - Mail out contributor and security researcher mugs
+      - Space out the ordering of mugs over the next three weeks to prevent mistakes being made by the supplier (e.g., If there are 12 contributors to order mugs for, place an order every 2nd or 3rd day over the next three weeks)
+    - Update [Team](http://www.mattermost.org/team/) page with new contributors
+3. QA:
+    - Confirm up to date with testing PRs and resolved tickets
+    - Confirm up to date with test updates and known issues in release test management and automated tests
+    - Assign release testing areas to team members
+    - After RC1 is cut: Update test server invite links in Release Testing instructions
+    - After RC1 is cut: Run automated regression tests
+4. Build:
+    - Review all `TODO` notes, including one for uncommenting upgrade code
+    - Confirm all PRs in [`/enterprise`](https://github.com/mattermost/enterprise/pulls) repo have been merged
+    - Update Redux before each RC and Final build
+    - Update package version in [Mattermost DockerFile](https://github.com/mattermost/mattermost-server/blob/master/build/Dockerfile#L7)
+    - Master is tagged and branched and `Release Candidate 1` is cut (e.g. 3.5.0-RC1) according to the Release Candidate Checklist in `mattermost/process`
+    - After branching, the database version in `sql_upgrade.go` on master is set to the next scheduled release version (e.g., 3.6.0)
+
+### H. (T-minus 8 working days) Release Candidate Testing
+
+1. **(Team) Daily Release Update Meeting**
+    - Triage Jira tickets
+    - Decide when to cut next RC
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Post list of tickets to be fixed to the Release Discussion channel ([see example](https://community.mattermost.com/core/pl/65k77x3bnigw5f9ffohfxonnfy))
+    - Update the GitHub meta issue:
+       - Include a link to the changelog on the documentation branch
+       - Update download links and testing server links to the latest RCs
+    - After build is cut, tweet announcement that RC1 is ready (see [example](https://community.mattermost.com/core/pl/tefx1ijyz7bs8mabuxmpq9f7pw))
+    - Update https://docs.mattermost.com/administration/open-source-components.html
+    - Ask martin.kraft to provide a list of Database changes, API changes, WebSocket event changes, and config.json setting changes for Changelog. [See example request](https://github.com/mattermost/docs/pull/3398#issuecomment-593411501)
+3. QA:
+    - Update Release Discussion header with links to RC instances and testing spreadsheet ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.ghe4vz9zd1v))
+    - Post release testing instructions to Release Discussion channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.u28aar2hx7hg))
+    - Post reminders in Announcements channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.pirw51cwsja5)) and Customer Support channel ([template](https://docs.google.com/document/d/1UvTsvwZXmEL9QPjxmjoIkR2AcwGtOjql8cYRfk2N8eA/edit#bookmark=id.ke0fh13gidni))
+    - DM reminders to team members who are not QA or devs, or who are new to release testing
+    - At end of day, post reminders about release testing in Release Discussion and Announcements channels, DM any team members who have zero test cells marked **Done**
+4. Logistics @hanna.park:
+    - Generate an E20 5000 seat test licence and email to Lindy for release testing
+5. Dev:
+    - Make PRs for bug fixes to the release branch
+    - Review PRs made from release branch and merge changes into the release branch as required
+    - Run daily automated upgrade tests to avoid catching upgrade bugs late
+6. Marketing:
+    - Finish draft of blog post for mattermost.com and all art work (screenshots, GIFs, and Twitter banners) used for the blog post
+        - Upgrade should be recommended if there are security fixes in this version, with a note thanking the security researcher
+    - Send blog post for Release Manager and PMs to review
+
+### I. (T-minus 7 working days) Release Candidate Testing Finished
+
+1. **(Team) Daily Release Update Meeting**
+    - Confirm testing assigned in the release testing spreadsheet is complete 
+    - Continue to triage Jira tickets
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Check that all features are behind a feature flag
+    - Confirm all config settings and new features have diagnostics
+    - Confirm Changelog reflects any changes since it was merged (including known issues and contributors from all repositories)
+      - Confirm translators and new integrations contributors have been added
+      - Confirm Open Source Components changes have been added
+    - Ask UX to [create a "Hero" screenshot as the splash image for the release blog post](https://handbook.mattermost.com/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements#one-great-screenshot-a-month)
+3. Marketing:
+    - Send blog post for mattermost.com and all related art work for marketing lead to review
+    - Find [www-gitlab-com merge request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests?scope=all&utf8=%E2%9C%93&state=opened&label_name%5B%5D=blog%20post&label_name%5B%5D=release) for latest GitLab release blog post and make request for adding GitLab Mattermost update (see [example request](https://gitlab.com/gitlab-com/www-gitlab-com/merge_requests/2910#note_14096885), [example update](https://about.gitlab.com/2016/07/22/gitlab-8-10-released/#gitlab-mattermost-32)). Post to Release Discussion channel with link to request.
+4. QA:
+    - Midday: Post reminders about testing, at-mentioning team members whose tests are not yet complete
+    - Find QA or other teammates to help finish unfinished tests if needed
+    - End of day or next morning: Verify all release tests are finished, bring any concerns to Triage / Release meeting
+    - Go through all tabs of testing spreadsheet and verify all comments and questions have been filed in Jira as needed
+    
+### J. (T-minus 5 working days) Code Freeze
+Day after which only **S1 regressions** should be fixed (crashes, security vulnerabilities) and no other code changes should be committed. Exceptions can be made by the Release Manager during triage on a case-by-case basis. Review the [Bug Severity Guidelines](https://docs.mattermost.com/process/bug-severity-guidelines.html).
+
+1. **(Team) Daily Release Update Meeting**
+    - Continue to triage Jira tickets
+    - If no blocking issues are found, PM, Dev, and QA sign off on the release and begin final smoke tests
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Verify that the final translations PR for the release is submitted
+    - Update **Known Issues** section with any significant issues that were found and not fixed for the final release
+    - Start drafting a release summary for Support/Sales highlighting key things (e.g., new features, breaking changes, things we want feedback on, and potential support issues)
+3. QA:
+    - Verify all Jira tickets other than newly-filed bugs have been tested, verified, and closed
+    - As bug fixes are merged and RCs are cut, verify fixes on new RCs, and post in Release Channel after testing
+    - After all tickets are verified and closed, run smoke tests on webapp/server, desktop app, and RN apps as appropriate 
+5. Docs:
+    - Submit Changelog PR for team review
+    - Submit any remaining documentation PRs for product updates in the release
+    - Check that a redirect page has been set up in mattermost.com for any links added to the System Console
+    - Submit documentation for [API changes](https://github.com/mattermost/mattermost-server/commits/master/model/client.go) and [WebSocket event changes](https://github.com/mattermost/mattermost-server/blob/master/model/websocket_message.go#L13) to API documentation
+    - Confirm changes to `config.json` in compatibility section of Changelog are written back to [settings documentation](http://docs.mattermost.com/administration/config-settings.html#configuration-settings)
+    - Confirm all new diagnostics are documented in the telemetry docs (https://docs.mattermost.com/administration/telemetry.html)
+
+### K. (T-minus 2 working days) Release Build Cut
+
+The final release is cut - RC cuts and bug fixes should be completed by this date. Only urgent and critical issues are considered for fixing.
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Work with a developer to submit GitLab MR [following this process](https://docs.mattermost.com/process/gitlab-process.html#merge-requests) and [test the upgrade](https://docs.google.com/document/d/1mbeu2XXwCpbz3qz7y_6yDIYBToyY2nW0NFZq9Gdei1E/edit#heading=h.ncq9ltn04isg) once the GitLab MR is merged and included in their RC
+    - Close GitHub meta ticket for the release
+    - Add the download links, SHA-256 hash, and GPG signature to the [version archive](http://docs.mattermost.com/administration/upgrade.html#version-archive)
+    - Merge Changelog PR after review is complete
+      - If there is a security fix, confirm the Changelog recommends upgrade, with a note mentioning the security level and thanking the security researcher (security process doc for example)
+    - Update the [Mattermost server download page](https://www.mattermost.org/download/) with the links to the Enterprise Edition and Team Edition sections
+      - Test the download links before and after updating the page
+    - Check security issues and confirm disclosure text
+    - Check the security researcher was added to the [Responsible Disclosure Policy](https://www.mattermost.org/responsible-disclosure-policy/) page
+    - Confirm link to security updates appears in blog post if there are security updates in this release, with a note thanking the security researcher
+    - Update [deprecated feature list](https://about.mattermost.com/deprecated-features/) in mattermost.com with new and scheduled deprecations
+    - Draft [Mattermost Security Updates](http://about.mattermost.com/security-updates/), but do not post until 30 days after official release 
+      - Add a placeholder text saying "Details on the security update will be posted here on X date, as per our Responsible Disclosure Policy"
+2. QA:
+    - Verify all PRs and tickets for the release have been tested/closed
+    - Verify Selenium server was put on final RC and build passed
+    - Verify smoke tests on webapp/server, desktop app, and RN apps all passed
+    - Post QA approval in Release Discussion channel
+3. Build:
+    - Update Redux before each RC and Final build
+    - Tags a new release (e.g. 1.1.0) and runs an official build which should be essentially identical to the last RC
+    - Posts SHA key, md5 sum, and GPG signatures of the final build to Release Discussion channel
+    - Post in Release Discussion with links to the Enterprise Edition and Team Edition sections
+4. Dev:
+    - Verify the hashes (SHA-1, SHA-256, and md5) and GPG signatures are correct for both Enterprise Edition and Team Edition
+    - Test upgrade from previous version to current version, following the [Upgrade Guide](http://docs.mattermost.com/administration/upgrade.html#upgrade-guide) with database upgrades on both MySQL and Postgres
+    - Test upgrade from Team Edition to Enterprise Edition based on the [Upgrade Guide](https://docs.mattermost.com/administration/upgrade.html#upgrade-team-edition-to-enterprise-edition)
+    - Test fresh install of current version, following the [Install Guide](https://docs.mattermost.com/guides/administrator.html#installing-mattermost)
+    - Review any changes made to install guides, and test if necessary
+    - Ensure [Security Policies](https://docs.mattermost.com/process/security.html) page has been updated
+    - Update dependancies after release branch is cut in `mattermost-server`, `mattermost-webapp`, `desktop`, `mattermost-mobile`, and `mattermost-redux`
+5. Logistics @hanna.park:
+    - Order the release MVP winner's coaster
+6. Docs:
+    - Finalize docs
+      - If reviews are not complete, hold a 30 minute doc review meeting with PMs and anyone else who has changed or reviewed docs this release and wants to join
+      - Merge the docs release branch to master and verify all changes on docs.mattermost.com once the build is up
+      - Submit a correction PR for any incorrect formatting or other errors missed during the initial review
+7. Marketing:
+    - Receive sign off on final version of MailChimp email blast and Twitter announcement and schedule for 08:00 PST on the date of marketing announcement
+      - **Note:** If the release contains a security update, also draft a Mailchimp email blast for the [Security Bulletin mailing list](http://eepurl.com/cAl5Rv)
+    - Finalize blog post for mattermost.com, test on mobile view, and set timer for 08:00 PST on the day of release
+    - Add links to [Admin guide](https://docs.mattermost.com/guides/administrator.html) in the release blog post where needed
+
+### L. (T-minus 0 working days) Release Day
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Schedule a release retrospective meeting, to be held within five days from the release
+    - Prepare and post [release metrics](https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oVw-M/edit#gid=825551144)
+    - Review and update [company roadmap](https://about.mattermost.com/direction/) with which major features made it into the release
+        - Review with Head of Product prior to updating
+        - Also update feature lists on https://mattermost.com/pricing/ and https://mattermost.com/product/ with relevant new features where needed
+    - Update Integrations Directory on the [Mattermost Apps and Integrations](https://integrations.mattermost.com/) page
+    - Post the MVP winner announcement in the [Contributors channel](https://community.mattermost.com/core/channels/tickets)
+    - Update [MVP page](https://www.mattermost.org/mvp/) with the most valued professional of the release
+    - Add new release fix versions in Jira for the next few releases
+    - Post key dates for the next release in the Release Discussion channel and remove links to RC candidates and testing spreadsheet from the header
+        - Make sure that statutory holidays for Canada and US are accounted for in the release dates
+    - Check for any [UserVoice](https://docs.google.com/spreadsheets/d/1nljd4cFh-9MXF4DxlUnC8b6bdqijkvi8KHquOmK8M6E/edit#gid=0) feature suggestions that were completed in the current release
+      - Find the [release tweet](https://twitter.com/mattermosthq/status/854781715914555393) and insert a link to the tweet next to the feature that shipped with the release.
+    - Close the release in Jira both for webapp and mobile ([releases page](https://mattermost.atlassian.net/projects/MM?selectedItem=com.atlassian.jira.jira-projects-plugin%3Arelease-page))
+    - For the next release, create the following team meetings. If they conflict with existing meetings, check with meeting owner to reschedule or reschedule the release meeting
+      - Bug Bash Meeting on the week after Code Complete at 10:00am San Francisco time
+      - Judgment Day Meeting on T-15 at 10:00am San Francisco time
+      - Code Complete Meeting on T-14 at 10:00am San Francisco time
+      - Release Triage and Update Meeting each weekday starting at T-15 and ending at T-2 at 9:30am San Francisco time for PM, QA and release dev.
+    - Prepare tickets for the next release, with a corresponding vX.X prefix, and put the tickets in the appropriate sprints as follows:
+       - The week RC is cut:
+            - [RC Build Testing for core team](https://mattermost.atlassian.net/browse/PLT-2208)
+       - The week RC is cut:
+            - [Loadtest x.x release candidate compared to x.x release](https://mattermost.atlassian.net/browse/MM-12532)
+       - The week RC is cut (for GitLab dev owner):
+            - Test RC1 with the latest GitLab build during release testing cycle
+       - Release week (for dependancies owner)
+            - Upgrade dependancies for webapp, server, and Redux
+       - Week after release (for GitLab dev owner)
+            - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
+    - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
+    - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
+      - For Puppet, Heroku, and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/fgjqthmn67nujjtx4fcrn1hd9a)
+      - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/ist-dsi/mattermost-cookbook/issues/22)
+      - For Yunohost, open a new pull request to update the version. See [example](https://github.com/YunoHost-Apps/mattermost_ynh/pull/103)
+2. Docs:
+    - Create a new branch on docs for the next release - `vX.X-documentation`
+        - Submit a PR for Changelog against the `vX.X-documentation` branch and add a `Work in Progress` label for it
+        - Submit a PR to change version number in `docs/source/conf.py` against the `vX.X-documentation` branch
+3. Build:
+    - Cut release branch for Bug Fix release
+        - Ensure `community-release` is on the quality release branch
+    - Put CI servers and translation server back onto master, and post in Private Developers channel once done
+    - Ensure https://community.mattermost.com is on the most recently released version and that https://prev.test.mattermost.com is on the most recently released bug fix release
+4. Marketing:
+    - Turn on CrazyEgg for blog post page
+    - Confirm marketing has been posted (animated GIFs, screenshots, mail announcement, tweets, blog posts)
+    - Update @mattermosthq Twitter profile with the next release date
+    - Prepare retweet of GitLab release tweet ([see example here](https://community.mattermost.com/core/pl/k7wchwj5mtrhucj6don96yx3sc))
+5. QA:
+    - Merge any updates made to Selenium tests during release testing
+    - Update RN server URLs to Rainforest
+
+### M. (T-plus 30 days) Update Mattermost Security Page
+
+1. Release Manager:
+    - Post [Mattermost Security Updates](https://about.mattermost.com/security-updates/) after reviewing with security lead
+      - If a dot release is shipping with security fixes, do not post new details until T-plus 10 working days from the dot release ship date

--- a/operations/research-and-development/product/release-process/mobile-release.md
+++ b/operations/research-and-development/product/release-process/mobile-release.md
@@ -1,0 +1,137 @@
+# Mobile App Release Process
+
+The Mattermost Mobile Apps team works on a monthly release process, with a new version submitted to the iOS App Store and Google Play Store on the 16th of each month. 
+
+**Note: iOS App Store approval may take a few days after the 16th.**
+
+## Release Timeline
+
+Notes:
+
+- All cut-off dates are based on 10am ([San Francisco Time](https://everytimezone.com/)) on the day stated.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [the listed statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
+
+### A. (T-minus 15 working days) Cut-off for merging major features
+
+No pull requests for major features should be **merged** to the current release after this date. In special cases, exceptions can be made by the Release Manager.
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Draft Changelog in a WIP PR with updates for highlights, feature additions and bug fixes
+    - Start posting a daily Zero Bug Balance query (posted until zero bugs or day of release)
+2. PM:
+    - Prioritize reviewing major features, ensuring any bugs and UX issues get fixed
+3. Dev:
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the pull request queue marked for the current release
+      - After the cut-off, any PRs that include significant code changes, require approval of the Release Manager and React Native PM before merging
+4. Build:
+    - Cut a beta build
+5. Marketing:
+    - Prepare a list of highlights to be included in the next Mattermost release announcement
+
+### B. (T-minus 14 working days) Major Feature Testing
+
+1. QA:
+    - Prioritize testing merged PRs and resolved tickets
+    - Write and update tests in the Release Testing spreadsheet
+    
+### C. (T-minus 13 working days) Judgment Day
+
+Day when PM decides which major features are included in the release, and which are postponed.
+
+1. **(Team) Triage Meeting**:
+    - Begin daily triage of tickets
+2. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Update Changelog PR based on what's in/out of the release
+    - Post a link to Native Mobile Apps channel for query of remaining bugs in this release
+3. PM:
+    - Review the Jira tickets remaining in the current release fix version and push those that won't make it to the next fix version
+
+### D. (T-minus 9 working days) Code Complete and Release Candidate Cut 
+
+**Stabilization** period begins when all features for release have been committed. During this period, only **bugs** can be committed to the release branch. Non-bug pull requests are tagged for next version. Exceptions can be made by the Release Manager during triage.
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+2. Dev:
+    - Prioritize reviewing, updating, and merging of pull requests for current release until there are no more tickets in the pull request queue marked for the current release
+    - Check the minimum server version required and submit pull request to update in fastlane files
+3. Build:
+    - Create release branch for mattermost-mobile and mattermost-redux
+    - Cut release candidate build
+4. QA:
+    - Confirm all pull requests merged into the current release have been tested
+    - Ensure the release testing spreadsheet covers any changes and new features, and confirm known issues are listed in the relevant tests
+    - Assign each area of the spreadsheet to a team member and give the core team access permissions
+5. Docs:
+    - Submit any remaining documentation PRs for product updates in the release
+
+### E. (T-minus 8 working days) Release Candidate Testing
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Post list of tickets to be fixed to the Native Mobile Apps channel
+    - Update Changelog for any new bug fixes
+2. QA:
+    - Post release testing instructions and spreadsheet to Release Discussion channel
+    - As bug fixes are merged, verify fixes on new builds and post in Native Mobile Apps channel after testing
+3. Team:
+    - Test assigned areas of the testing spreadsheet and file any bugs found in Jira 
+    - Daily triage of hotfix candidates and decide on whether and when to cut next RC or final
+4. Dev:
+    - Make pull requests for hotfixes to the release branch
+    - Review PRs made to release branch and merge changes into the release branch
+5. Build:
+    - Verify with Release Manager before cutting any new RCs (approved fixes should be merged)
+    - Push next RC to acceptance and announce in Native Mobile Apps channel
+6. PM:
+    - Check that the release candidate is available to beta testers 
+7. QA: 
+    - Test the new RC to verify fixes merged to the release branch work
+
+### F. (T-minus 2 working days) Release Build Cut
+
+The final release is cut. If an urgent and important issue needs to be addressed between major releases, a bug fix release (e.g., 1.1.1) may be created.
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Submit Changelog PR for review
+        - Merge Changelog PR after review is complete
+2. Build: 
+    - Tags the release and cuts the final build
+    - Upload the ``.ipa`` and ``.apk`` files to GitHub
+3. Marketing:
+    - Finish draft of marketing images and send to marketing lead for review
+4. Docs:
+    - Finalize docs
+      - If reviews are not complete, hold a 30-minute doc review meeting with PMs and anyone else who has changed or reviewed docs this release and wants to join
+      - Submit a correction PR for any incorrect formatting or other errors missed during the initial review
+    
+### G. (T-minus 0 working days) Release Day and Build Submitted to App Stores 
+
+1. Release Manager:
+    - Post this checklist in Release Checklist channel
+    - Verify all items in the last posted release checklist are complete
+    - Schedule a release retrospective meeting, to be held within five days from the release 
+    - Post key dates for the next release in the header of the Native Mobile Apps channel and remove links to RC candidates and testing spreadsheet
+        - Make sure that statutory holidays for Canada and US are accounted for in the release dates
+    - Check for any [UserVoice](https://docs.google.com/spreadsheets/d/1nljd4cFh-9MXF4DxlUnC8b6bdqijkvi8KHquOmK8M6E/edit#gid=0) feature suggestions that were completed in the current release
+2. Build:
+    - Merge the release branch back in to master
+    - Review and update project dependencies as needed
+    - Submit final build to Google Play Store and iTunes Connect
+    - Confirm that minimum server version required is clear in update notes 
+    - Create release in GitHub 
+    - Close the release in Jira
+
+### H. (T-plus X days) Release Marketing
+
+1. Marketing:
+    - After the apps are approved and on the App Store (number of days may vary), send out release marketing
+    - Update the app version on the [download page](https://about.mattermost.com/download/#mattermostApps)
+    - Send out a Twitter announcement

--- a/operations/research-and-development/product/release-process/release-overview.md
+++ b/operations/research-and-development/product/release-process/release-overview.md
@@ -1,0 +1,126 @@
+# Release Overview
+
+Mattermost adopts a monthly tick-tock release cycle, with a new version shipping on the 16th of each month in [binary form](http://docs.mattermost.com/administration/upgrade.html#mattermost-team-edition).
+
+Tick-tock refers to even-numbered releases (e.g., v5.6) containing new features, and odd-numbered releases (e.g., v5.7) containing only bug fixes and performance improvements.
+
+The primary goal of our release cycle is to improve quality and build trust with our users in every release. A tick-tock release cycle allows new features to soak in our test environments for longer, allowing us to identify and fix bugs before releasing the features.
+
+There is no change to the process or release schedule for security issues. When security issues are found that warrant a patch release, we follow the [security release process outlined here](https://docs.mattermost.com/process/security-release.html).
+
+## Release Numbering
+
+Mattermost numbers stable releases in the following format:
+**[Version Number].[Major Build Number].[Minor Build Number]**
+
+**Version Number:**
+
+- Purpose: Major system releases introduce significantly new functionality or change existing product behaviour
+- Release frequency: Unscheduled. Major system releases are infrequent
+- Example: v1.x.x, v2.x.x
+
+**Major Build Number:**
+
+- Purpose: Introduce new features, bug fixes and performance improvements
+- Release frequency: Monthly on the 16th of each month
+- Example:
+  - Even numbers (e.g. v1.2.x, v1.4.x): New features and bug fixes
+  - Odd numbers (e.g. v1.3.x, v1.5.x): Quality release including performance improvements and bug fixes
+
+**Minor Build Number:**
+
+- Purpose: Patch existing releases when severe bug fixes or security patches are required
+- Release frequency: As required
+- Example: v1.2.5, v1.2.6
+
+## Frequently Asked Questions
+
+**Q: Will tick-tock releases delay features?**
+
+  - A: You can view current, near term, and future priorities on [our website here](https://mattermost.com/roadmap/). While tick-tock releases mean only shipping new features every other release, it improves the quality of features shipped. We want to avoid rushing to ship new features and then fixing bugs over a number of releases, and instead we focus on shipping high-quality features out the gate.
+
+**Q: What is the release cycle for the React Native mobile apps?**
+
+  - A: The mobile apps follow the same monthly tick-tock release cycle as Mattermost Server/Webapp, releasing on the 16th of each month.
+
+**Q: What is the release cycle for the Mattermost Desktop app?**
+
+  - A: Desktop releases are currently released as required. We hope to move Desktop to a more frequent and scheduled release cycle in the near future.
+
+**Q: When is release branch cut for a quality release?**
+
+  - A: On the day prior feature release ships after final has been cut.
+
+**Q: When is release branch cut for a feature release?**
+
+  - A: On feature cut-off date (T-20).
+
+**Q: How are PRs merged for release?**
+
+  - A: PRs are first merged to master. The dev who submitted the fix is then responsible for cherry-picking it to the quality release branch.
+
+**Q: How are PRs merged for a feature release?**
+
+  - A: PRs are submitted and merged to master (no change).
+
+**Q: How does quality release work?**
+
+  - A: Bugs are branched off from the previous feature release.
+
+**Q: How is cherry-picking done?**
+
+  - A: See the [cherry pick process documentation](https://developers.mattermost.com/contribute/getting-started/branching/#cherry-pick-process-developer/) for details.
+
+**Q: What is community.mattermost kept on?**
+
+  - A: community.mattermost is kept on the latest released release.
+
+**Q: What is community-release.mattermost kept on?**
+
+  - A: community-release.mattermost is kept on the currently in progress release. Once the release branch is cut for a release, then community-release.mattermost is updated to that release branch.
+
+**Q: What is community-daily.mattermost kept on?**
+
+  - A: Normally on `master` branch.
+
+**Q: How to remove a feature/bug from a release?**
+
+  - A: Revert from release branch. Optionally revert from master.
+
+**Q: How are NOTICE.txt PRs submitted?**
+
+  - A: PRs are first merged to master. The dev who submitted the fix is then responsible for cherry-picking it to the release branch.
+
+**Q: Is an improvement a feature or a bug?**
+
+  - A: Usually features/story tickets.
+
+**Q: How does release team monitor what changes went into a release?**
+
+  - A: Monitor the commit history of the respective release branch, e.g., https://github.com/mattermost/mattermost-server/commits/release-5.4 contains commits that shipped with mattermost-server v5.4. Jira ticket is resolved after cherry picking is done.
+
+**Q: What changes were made to the dev release process to account for the rotating feature and quality releases?**
+
+  - A: See https://developers.mattermost.com/internal/release-process/. A PR with changes was merged
+    [here](https://github.com/mattermost/mattermost-developer-documentation/pull/182).
+
+**Q: What changes were made to the team release process to account for the rotating feature and quality releases? https://docs.mattermost.com/process/release-process.html**
+
+  - A: Separate checklists for [Quality release](https://docs.mattermost.com/process/bug-fix-release.html)
+    and [Feature release](https://docs.mattermost.com/process/feature-release.html) were created.
+
+**Q: How does translations branching work?**
+
+  - A: Lock the translation server to the release branch. The translation PR will be submitted against the release branch and it can just be merged directly to the release branch without cherry-picking. When the translation server is locked back to master, the next PR against master will include those translations that went in for the release branch.
+
+**Q: How does cutting mobile builds work?**
+
+  - A: See instructions here: https://developers.mattermost.com/internal/mobile-build-process/.
+
+**Q: How does updating dependencies work?**
+
+  - A: Dependency updates will only occur in feature releases, unless they contain security fixes.
+
+**Q: What is the process for community PRs?**
+
+  - A: Review, merge, and cherry-pick.

--- a/operations/research-and-development/product/release-process/release-scorecard-definitions.md
+++ b/operations/research-and-development/product/release-process/release-scorecard-definitions.md
@@ -1,0 +1,237 @@
+# Release Scorecard Definitions
+
+For
+https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oVw-M/edit#gid=825551144
+
+## Release Output
+
+<table>
+<colgroup>
+<col style="width: 46%" />
+<col style="width: 53%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Metric</th>
+<th>How to Measure</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Ratio of story-to-bug tickets</td>
+<td>Total of feature tickets over total of bug tickets. Include current quality release and previous feature release.</td>
+</tr>
+<tr class="even">
+<td>Mean time from P1 bug report to delivery</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Bug</li>
+<li>Label = P1</li>
+<li>Created Date = 17th of the previous month</li>
+<li>Release Date = 16th of the current month</li>
+</ol>
+<p>Copy a list of Jira tickets with the above information and paste them into a spreadsheet. Calculate the average by using a formula “=Release Day-Created”.</p></td>
+</tr>
+<tr class="odd">
+<td>Mean time from P2 bug report to delivery</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Bug</li>
+<li>Label = P2</li>
+<li>Created Date = 17th of the previous month</li>
+<li>Release Date = 16th of the current month</li>
+</ol>
+<p>Copy a list of Jira tickets with the above information and paste them into a spreadsheet. Calculate the average by using a formula “=Release Day-Created”.</p></td>
+</tr>
+<tr class="even">
+<td>Mean time from P3 bug report to delivery</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Bug</li>
+<li>Label = P3</li>
+<li>Created Date = 17th of the previous month</li>
+<li>Release Date = 16th of the current month</li>
+</ol>
+<p>Copy a list of Jira tickets with the above information and paste them into a spreadsheet. Calculate the average by using a formula “=Release Day-Created”.</p></td>
+</tr>
+<tr class="odd">
+<td>Number of P1 bugs reported in production</td>
+<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+</tr>
+<tr class="even">
+<td>Number of P2 bugs reported in production</td>
+<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+</tr>
+<tr class="odd">
+<td>Number of P3 bugs reported in production</td>
+<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+</tr>
+</tbody>
+</table>
+
+## Release Management
+
+<table>
+<colgroup>
+<col style="width: 46%" />
+<col style="width: 53%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Metric</th>
+<th>How to Measure</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Number of misses in each release cycle</td>
+<td>Same as number of bugs reported in production, + count of issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
+</tr>
+<tr class="even">
+<td>Number of setbacks to users/staff resulting in a negative reaction</td>
+<td>Manual count of negative reactions reported by CSMs, Support or Product. E.g. features that got pushed.</td>
+</tr>
+<tr class="odd">
+<td>Number of measurable actions from each release retrospective driven from root causes & completed and reported to R&D</td>
+<td>Count of completed and reported items from Release Retrospective document.</td>
+</tr>
+<tr class="even">
+<td>Number of deadlines missed in release checklist</td>
+<td>Manual count of deadlines not met from items posted to Release Checklist.</td>
+</tr>
+</tbody>
+</table>
+
+## Release Hearbeat
+
+<table>
+<colgroup>
+<col style="width: 34%" />
+<col style="width: 65%" />
+</colgroup>
+<thead>
+<tr class="header">
+<th>Metric</th>
+<th>How to Measure</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Time updated to RC1 (PST)</td>
+<td>Check Release Discussion channel history for date/time RC1 was cut.</td>
+</tr>
+<tr class="even">
+<td>How many RCs cut</td>
+<td>Check Release Discussion channel history for how many RCs were cut for that release.</td>
+</tr>
+<tr class="odd">
+<td>Number of days between when final RC is cut and the release date</td>
+<td>Check Release Discussion channel for post with official release build. Oxygen = 16th - Day Final RC is cut</td>
+</tr>
+<tr class="even">
+<td>Community + customer bugs reported during release timeframe (17th to 16th)</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Bug</li>
+<li>Label = Customer-bug and Community-bug</li>
+<li>Created Date = 17th of the previous month</li>
+<li>Release Date = 16th of the current month</li>
+</ol></td>
+</tr>
+<tr class="odd">
+<td>Number of customer bugs fixed during release</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Bug</li>
+<li>Status = Closed and Resolved</li>
+<li>Label = Customer-bug</li>
+</ol></td>
+</tr>
+<tr class="even">
+<td>Total valid bugs in fix version</td>
+<td><p>After closing current release:</p>
+<p>project = Mattermost AND issuetype = Bug AND resolution not in (Duplicate, "Cannot Reproduce", "Won't Fix") AND fixVersion = latestReleasedVersion()</p></td>
+</tr>
+<tr class="odd">
+<td>Total valid bugs in fix version found by test automation</td>
+<td>Check "Se", "Selenium-found, "Rainforest-found" Jira labels.</td>
+</tr>
+<tr class="even">
+<td>Total valid bugs found after RC1 is cut</td>
+<td><p>After closing current release, adjust dates as per above, and use this Jira query:</p>
+<ol type="1">
+<li>Check Jira timezone + Pre-release timezone and make sure times match</li>
+<li>Replace START with date (yyyy-MM-dd HH:mm) RC1 was cut</li>
+<li>Replace END with date (yyyy-MM-dd HH:mm) test servers returned to master</li>
+</ol>
+<p>project = Mattermost AND issuetype = Bug AND resolution not in (Duplicate, "Cannot Reproduce", "Won't fix") AND created &gt; "START" AND created &lt; "END"</p></td>
+</tr>
+<tr class="even">
+<td>Valid bugs found after RC1 fixed in release</td>
+<td><p>After closing current release, adjust dates as per above, and use this Jira query:</p>
+<p>project = Mattermost AND issuetype = Bug AND resolution not in (Duplicate, "Cannot Reproduce", "Won't Fix") AND created &gt; "START" AND created &lt; "END" AND fixVersion = latestReleasedVersion()</p></td>
+</tr>
+<tr class="odd">
+<td>Valid bugs found after RC1 pushed to next release</td>
+<td><p>After closing current release, adjust dates as per above, and use this Jira query:</p>
+<p>project = Mattermost AND issuetype = Bug AND resolution not in (Duplicate, "Cannot Reproduce", "Won't Fix") AND created &gt; "START" AND created &lt; "END" AND fixVersion = earliestUnreleasedVersion()</p></td>
+</tr>
+<tr class="even">
+<td>Valid bugs found after RC1 fix version = other (eg unscheduled, not set)</td>
+<td><p>After closing current release, adjust dates as per above, and use this Jira query:</p>
+<p>project = Mattermost AND issuetype = Bug AND created &gt; "START" AND created &lt; "END" AND resolution not in (Duplicate, "Cannot Reproduce", "Won't Fix") AND (fixVersion not in (latestReleasedVersion(), earliestUnreleasedVersion()) OR fixVersion is EMPTY)</p></td>
+</tr>
+<tr class="odd">
+<td>(Non-security) Bugs requiring patch release</td>
+<td>After any patch release goes out (after the normal release date): Check Changelog for total number of non-security patch releases.</td>
+</tr>
+<tr class="even">
+<td>Total features/improvements in fix version</td>
+<td><p>With a new or existing Jira filter, with:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Issue Type = Story</li>
+<li>Status = Closed and Resolved</li>
+</ol></td>
+</tr>
+<tr class="odd">
+<td>Critical security issues found during release timeframe</td>
+<td><p>With a new or existing Jira filter, check for Security Vulnerability tickets:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Impact = High</li>
+</ol></td>
+</tr>
+<tr class="even">
+<td>Moderate security issues found during release timeframe</td>
+<td><p>With a new or existing Jira filter, check for Security Vulnerability tickets:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Impact = Medium</li>
+</ol></td>
+</tr>
+<tr class="odd">
+<td>Minor security issues found during release timeframe</td>
+<td><p>With a new or existing Jira filter, check for Security Vulnerability tickets:</p>
+<ol type="1">
+<li>Project = Mattermost</li>
+<li>Fix Versions = Latest released version</li>
+<li>Impact = Low</li>
+</ol></td>
+</tr>
+</tbody>
+</table>
+

--- a/operations/research-and-development/product/release-process/release-scorecard-definitions.md
+++ b/operations/research-and-development/product/release-process/release-scorecard-definitions.md
@@ -62,15 +62,15 @@ https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oV
 </tr>
 <tr class="odd">
 <td>Number of P1 bugs reported in production</td>
-<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
 </tr>
 <tr class="even">
 <td>Number of P2 bugs reported in production</td>
-<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
 </tr>
 <tr class="odd">
 <td>Number of P3 bugs reported in production</td>
-<td>**Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
 </tr>
 </tbody>
 </table>

--- a/operations/research-and-development/product/release-process/release-scorecard-definitions.md
+++ b/operations/research-and-development/product/release-process/release-scorecard-definitions.md
@@ -62,15 +62,15 @@ https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oV
 </tr>
 <tr class="odd">
 <td>Number of P1 bugs reported in production</td>
-<td>Count of major issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
+<td>Count of major issues reported in product, documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 <tr class="even">
 <td>Number of P2 bugs reported in production</td>
-<td>Count of medium level issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
+<td>Count of medium level issues reported in product, documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 <tr class="odd">
 <td>Number of P3 bugs reported in production</td>
-<td>Count of small issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
+<td>Count of small issues reported in product, documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 </tbody>
 </table>

--- a/operations/research-and-development/product/release-process/release-scorecard-definitions.md
+++ b/operations/research-and-development/product/release-process/release-scorecard-definitions.md
@@ -62,15 +62,15 @@ https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oV
 </tr>
 <tr class="odd">
 <td>Number of P1 bugs reported in production</td>
-<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Count of major issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 <tr class="even">
 <td>Number of P2 bugs reported in production</td>
-<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Count of medium level issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 <tr class="odd">
 <td>Number of P3 bugs reported in production</td>
-<td>Bug severity guidelines are in progress, after which a Jira query will be built</td>
+<td>Count of small issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
 </tr>
 </tbody>
 </table>
@@ -91,7 +91,7 @@ https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oV
 <tbody>
 <tr class="odd">
 <td>Number of misses in each release cycle</td>
-<td>Same as number of bugs reported in production, + count of issues reported in documentation or marketing by customers, CSMs, Support or Product. E.g. dot releases from customer reports, undocumented breaking changes.</td>
+<td>Count of issues encountered during the release cycle. E.g. no early advance notification of upcoming deprecated ESR.</td>
 </tr>
 <tr class="even">
 <td>Number of setbacks to users/staff resulting in a negative reaction</td>

--- a/operations/research-and-development/product/release-process/release-scorecard-definitions.md
+++ b/operations/research-and-development/product/release-process/release-scorecard-definitions.md
@@ -91,7 +91,7 @@ https://docs.google.com/spreadsheets/d/1Aoj4OTaWoyrKIcQNiHH1MVoRG51T20Y_0w2tg5oV
 <tbody>
 <tr class="odd">
 <td>Number of misses in each release cycle</td>
-<td>Count of issues encountered during the release cycle. E.g. no early advance notification of upcoming deprecated ESR.</td>
+<td>Count of issues encountered during the release cycle. E.g. no process for an early advance notification for upcoming deprecated ESR.</td>
 </tr>
 <tr class="even">
 <td>Number of setbacks to users/staff resulting in a negative reaction</td>

--- a/operations/research-and-development/product/release-process/release-tips.md
+++ b/operations/research-and-development/product/release-process/release-tips.md
@@ -1,0 +1,54 @@
+# Release Tips
+
+**Changelog Checklist**
+ 
+ - Features
+   - State benefits first.
+   - Order features based on benefit for end users.
+   - Include links to docs where appropriate.
+ - Bugs
+   - Check/test if the issue was in previous server version.
+ - All sections
+   - Check that all sections are written and formatted the same way as in previous Changelogs.
+ - API/Websocket/Database
+   - Work with Dev Ops on this section.
+ - Next version
+   - If the Changelog mentions items regarding upcoming versions, move them to the bottom of the Changelog.
+   
+**Ways to Meet Deadlines**
+
+ - Post a list of dates for next release at or soon after T-0 and ping all of the teams.
+ - For features and bugs, start pinging early enough before due dates and make public posts.
+ - When pinging people, provide a clear due date and give a reason for the due date (e.g., Code Complete on Monday).
+ - Ask if people need any help or have any questions.
+ 
+**Translations**
+
+ - Post a reminder at T-12 for translators about the release translations due date, e.g., https://community.mattermost.com/core/pl/466tkyxfdtftirxj31n8gpou5h.
+ - Monitor progress of translations at https://translate.mattermost.com/projects/mattermost/ and ping language maintainers a few days before due date if they're not getting to 100%.
+ - Ask Elias to hold on submitting final translations PR if some translators need more time, or ask him to submit a new one if a translations PR was already submitted.
+ - Target date for final translations PR is T-5, but T-3 is acceptable.
+
+**Ways That [Features/Bugs Guidelines](https://docs.google.com/document/d/1QxB_A1qkEJBKAvQpRa7JiSQLZhwg6HAEajNRNa7ldGg/edit) are Currently Enforced**
+
+ - Features guidelines:
+    - Sometimes features are merged after T-12.
+    - Start to ping people already at T-15 or earlier for feature PRs that are still open.
+ - Bugs guidelines:
+   - Need to focus on fixing only S1 and S2 bugs after T-5 to avoid missing T-2 deadline for cutting the final.
+   
+**Ways to Ensure Features are Tested for HA/Mobile/Scale**
+
+ - Mobile: Added a release checklist item for QAs for T-11.
+ - HA: Test server available.
+ - Scale: Via loadtests.
+
+**Release Marketing**
+
+ - Blog post:
+    - Follow [guidelines](https://docs.mattermost.com/process/marketing-guidelines.html#guidelines-for-release-announcements).
+    - Audience: end-users, admin/tech.
+    - Include CTAs and avoid including external links unless they direct to Mattermost website or documentation.
+    - Give release outline for all PMs and Rich before giving to Justin.
+  - Email:
+    - Check that the link on the email banner is correct.

--- a/operations/research-and-development/product/release-process/security-release.md
+++ b/operations/research-and-development/product/release-process/security-release.md
@@ -1,0 +1,63 @@
+# Security Release Process
+
+If a security fix release is required, run through the below steps.
+
+## Release Timeline
+
+Notes:
+- All cut-off dates are based on 10am ([San Francisco Time](http://everytimezone.com/)) on the day stated.
+- T-minus counts are measured in "working days" (weekdays, Monday through Friday, excluding [the listed statutory holidays](https://docs.mattermost.com/process/working-at-mattermost.html#holidays)) prior to release day.
+
+### A. (T-minus 4 working days) Code Complete
+
+1. Release Manager:
+    - Once the list of security issues to be fixed is finalized, post this checklist in Release Checklist channel
+    - Notify community about upcoming security release through a Twitter announcement and in changelog with links to approved fixes and a date tagged as "TBD"
+    - Email GitLab release team about upcoming security release
+    - Work with a developer to submit GitLab MR [following this process](https://docs.mattermost.com/process/gitlab-process.html#merge-requests) and [test the upgrade](https://docs.google.com/document/d/1mbeu2XXwCpbz3qz7y_6yDIYBToyY2nW0NFZq9Gdei1E/edit#heading=h.ncq9ltn04isg) once the GitLab MR is merged and included in their RC.
+     - Open a ticket to [submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-10365)
+    -  Make a post in Announcements channel announcing the security release to the rest of the team with links to approved tickets and include a link to the ticket to submit the GitLab MR
+2. Dev:
+    - PRs for hotfixes are made to release branch
+    - Review PRs made from release branch and merge changes into the release branch as required and merge the release branch back into master once per day
+
+### B. (T-minus 3 working days) Release Candidate Cut
+
+1. Build:
+    - Verify with Release Manager before cutting any new dot release RCs (approved fixes should be merged)
+    
+### C. (T-minus 2 working days) Release Candidate Testing
+
+1. QA:
+    - If the dot release takes place during a regular release, update ``prev.test.mattermost.com`` to dot-release RCs for the previous release and keep ``rc.test.mattermost.com`` on the latest regular release version
+    - Test the new RC to verify fixes merged to the release branch work
+    - Post in Release Discussion channel after testing
+2. Logistics:
+    - If the security researcher has not previously received a security researcher mug, order one for them 
+
+### D. (T-minus 0 working days) Release Build Cut
+
+Once security fix release is ready to cut:
+
+1. Dev:
+    - Tag a new release (e.g., 1.1.1) and run an official build
+    - Verify hashes and GPG signatures are correct, once build is cut
+    - Delete RCs after final version is shipped
+2. Release Manager:
+     - Update the Changelog
+     - Update the [version archive](https://docs.mattermost.com/administration/version-archive.html)
+     - Update the [ESR documentation](https://docs.mattermost.com/administration/extended-support-release.html#what-are-the-current-supported-esr-versions)
+     - Update [Mattermost server download page](https://mattermost.org/download) with the links to the EE and TE bits
+      - Test the download links before and after updating the page
+    - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
+    - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
+      - For Puppet, Heroku and Ansible Playbook, post to Installers and Images channel announcing the new release. See [example](https://community.mattermost.com/core/pl/5eh8fw3jaiyzzqoc6nfwfaioya).
+      - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/verifi-inc/mattermost/issues/2).
+      - For Yunohost, open a new pull request to update the version. See [example](https://github.com/kemenaran/mattermost_ynh/pull/11).
+      - For OpenShift, open a new pull request to update the version. See [example](https://github.com/goern/mattermost-openshift/pull/13).
+    - Update Security Research Hall of Fame on the [Responsible Disclosure Policy](https://about.mattermost.com/report-security-issue/) page
+    - Post [Mattermost Security Updates](https://about.mattermost.com/security-updates/) 30 days after the dot release has shipped
+      - Update Security Issues spreadsheet with issue number from posted update (e.g. v3.2.0.1)
+3. Marketing:
+    - Prepare [blog post](https://about.mattermost.com/releases/mattermost-4-10/) for mattermost.com, MailChimp email blast, and [Twitter announcement](https://twitter.com/mattermosthq/status/827193482578112512), and send to marketing lead for review. Once reviewed, schedule for 08:00 PST on the day after dot release
+    


### PR DESCRIPTION
Moving legacy handbook to handbook.mattermost.com is tracked as part of https://docs.google.com/spreadsheets/d/1Yz93lett6y-vPqyxqBFZhL_43xBQ2eYRUwcVyEat-lo/edit#gid=0

Accompanying docs PR: https://github.com/mattermost/docs/pull/3542