### PR TITLE
Fix "MLT" reference in left-hand side TOC

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -32,7 +32,7 @@
 
 * [Company Operations](operations/operations/README.md)
   * [Areas of Responsibility](operations/operations/areas-of-responsibility.md)
-  * [Management Leadership Team \(MLT\)](operations/operations/mlt-cadence/README.md)
+  * [Mattermost Leadership Team \(MLT\)](operations/operations/mlt-cadence/README.md)
     * [MLT Cadence V2MOM](operations/operations/mlt-cadence/mlt-cadence-vpmom.md)
   * [Company Measures](operations/operations/company-metrics/README.md)
     * [V2MOM Metrics](operations/operations/company-metrics/company-v2mom-metrics.md)


### PR DESCRIPTION
Should be "Mattermost Leadership Team", not "Management Leadership Team"