### PR TITLE
Update time for video game

### DIFF
--- a/operations/workplace/people/working-at-mattermost/workplace-program.md
+++ b/operations/workplace/people/working-at-mattermost/workplace-program.md
@@ -24,7 +24,7 @@ This activity is managed by People Team.
 
 ### Video Game Hour
 
-Into video games? Then join your fellow team to battle for the best at 10:30am Palo Alto time each Friday.
+Into video games? Then join your fellow team to battle for the best at 10:30 am Palo Alto time each Friday.
 
 Join the Social: Video Gaming channel to participate: https://community.mattermost.com/private-core/channels/social-gaming
 


### PR DESCRIPTION
Need to change the time for video game hour from 11:30 am to 10:30 am Palo Alto time.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
