### PR TITLE
Update NPS definitions

### DIFF
--- a/operations/business-operations/analytics/metrics-definitions.md
+++ b/operations/business-operations/analytics/metrics-definitions.md
@@ -216,19 +216,43 @@ As soon as one session ends, there is then an opportunity to start a new session
 
 * WIP
 
-## Net Promoter Score \(NPS\)
+### NPS Survey
+Mattermost NPS data is collected using an in-product survey on servers where the [User Satisfaction Survey plugin](https://docs.mattermost.com/integrations/net-promoter-score.html) is enabled. Users answer the question "How likely are you to recommend Mattermost?" by selecting a 0-10 score and can provide additional written feedback about their experience. Selecting a score and providing feedback are optional.
 
-Net Promoter Score is a standardized measure used by many organizations to measure and understand customer experience. It is a good indicator of customer satisfaction and growth. Mattermost NPS is calculated using user NPS responses provided by users with the NPS plugin enabled on their Mattermost server. Users can submit multiple scores, so in order to accurately represent NPS, the latest score is used when calculating current NPS. To track NPS historically, the latest user score submitted on or before the historical record month is used.
+Net Promoter Score is computed as **\(% Promoters - % Detractors\)** and ranges from -100 \(every user is a Detractor\) to +100 \(every user is a Promoter\) 
+  * Promoters \(score 9-10\): Loyal enthusiasts who will keep buying and refer others
+  * Passives \(score 7-8\): Satisfied but unenthusiastic users who are vulnerable
+  * Detractors \(score 0-6\): Unhappy users who can damage your brand
 
-* Net Promoter Score \(NPS\) measures customer experience and predicts business growth
-* Respondents are grouped as follows:
-  * Promoters \(score 9-10\) are loyal enthusiasts who will keep buying and refer others
-  * Passives \(score 7-8\) are satisfied but unenthusiastic customers who are vulnerable
-  * Detractors \(score 0-6\) are unhappy customers who can damage your brand
-* Net Promoter Score = 100 \* \(% Promoters - % Detractors\)
-  * NPS ranges from -100 \(every customer is a Detractor\) to 100 \(every customer is a Promoter\)
-* Mattermost's NPS is based off of a 1-10 ranking provided by customers
-  * If customers provide rankings 2+ times in a day, the last ranking of the day is used for NPS
+If users edit their response to the survey on any particular server version, only the latest rating on each server version is used for computing NPS. Test server data is also removed via the excludable servers list and by trimming any responses submitted on a server version that has not been publically available for 21 days (time delay before an NPS survey is triggered after a server upgrade).
+
+Based on the above calculation method, we can apply a time window (Quarterly Trailing NPS) and a version filter (NPS by Server Version) to represent and track the state of Mattermost NPS.  
+
+### Quarterly Trailing NPS
+
+[Quarterly Trailing NPS](https://mattermost.looker.com/dashboards/147) represents the NPS score computed based on survey submissions received in the last 90 days. We target a 90 day window of NPS responses because it:
+
+1. Encompases responses across all server versions that are currently in use by customers (with surveys enabled), meaning it is representative of the state of user experience that customers are facing today.
+2. Ensures we have a [statistically significant sample size](https://www.checkmarket.com/sample-size-calculator/) representing the [server versions currently in use](https://mattermost.looker.com/looks/203?toggle=dat,det,pik).
+3. Helps us capture week-week variations in NPS while being less volatile than NPS by server version given the larger sample size
+
+
+### NPS by Server Version
+
+[NPS by Server Version](https://mattermost.looker.com/dashboards/147) represents the NPS score computed based on survey submissions on a specific server version. While Quarterly Trailing NPS provides a representation of the state of user experience that our customers are facing, NPS by Server Version provides a representation of the user experience offered by the product in particular releases. As such, it's used heavily by the PM team to track the success of particular product team initiatives as they ship.
+
+NPS by Server Version is a lagging metric since we need to collect a statistically significant sample size before reporting NPS for a server version. Based on histroical data, ~2000 unique user responses (~1.5-2 months post-ship) are required for the NPS of a particular server version to stabilize. 
+
+NPS by server version can be volatile since it can be affected by the upgrade cadence of heavy usage servers. We typically see a surge in responses when surveys are triggered (21 days after server upgrade) for servers with large DAU that can impact the NPS trend for that server version. Quarterly trailing NPS is not as affected by this since the sample size is larger and responses are submitted on various server versions. 
+
+### Written Response Feedback
+
+Users can optionally submit written responses to the NPS survey. These responses are reviewed and categorized by the PM team to allow us to [stack rank](https://docs.google.com/spreadsheets/d/1cWqg_djHd_Xmq7cuG0YZj-lKmafgCHU_dU4KfRkClrY/edit#gid=0) certain initiatives for roadmap planning based on their impact to NPS, reach and effort to design, implement and test. 
+
+To determine impact to NPS, we can:
+1. Segment the reponses based written feedback from users who are detractors or passives (See the NPS Feedback section of the [NPS dashboard](https://mattermost.looker.com/dashboards/147))
+2. Segment the responses based on the categorization of the written feedback to analyze [what requested product enhancements equate to the lowest NPS scores from users](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=1937727547).
+3. View overall [number of responses by feedback category](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=831069489).
 
 
 ## Sales

--- a/operations/business-operations/analytics/metrics-definitions.md
+++ b/operations/business-operations/analytics/metrics-definitions.md
@@ -232,18 +232,18 @@ Based on the above calculation method, we can apply a time window (Quarterly Tra
 
 [Quarterly Trailing NPS](https://mattermost.looker.com/dashboards/147) represents the NPS score computed based on survey submissions received in the last 90 days. We target a 90 day window of NPS responses because it:
 
-1. Encompases responses across all server versions that are currently in use by customers (with surveys enabled), meaning it is representative of the state of user experience that customers are facing today.
+1. Encompasses responses across all server versions that are currently in use by customers (with surveys enabled), meaning it is representative of the state of user experience that customers are facing today.
 2. Ensures we have a [statistically significant sample size](https://www.checkmarket.com/sample-size-calculator/) representing the [server versions currently in use](https://mattermost.looker.com/looks/203?toggle=dat,det,pik).
-3. Helps us capture week-week variations in NPS while being less volatile than NPS by server version given the larger sample size
+3. Helps us capture week-to-week variations in NPS while being less volatile than NPS by server version given the larger sample size
 
 
 ### NPS by Server Version
 
 [NPS by Server Version](https://mattermost.looker.com/dashboards/147) represents the NPS score computed based on survey submissions on a specific server version. While Quarterly Trailing NPS provides a representation of the state of user experience that our customers are facing, NPS by Server Version provides a representation of the user experience offered by the product in particular releases. As such, it's used heavily by the PM team to track the success of particular product team initiatives as they ship.
 
-NPS by Server Version is a lagging metric since we need to collect a statistically significant sample size before reporting NPS for a server version. Based on histroical data, ~2000 unique user responses (~1.5-2 months post-ship) are required for the NPS of a particular server version to stabilize. 
+NPS by Server Version is a lagging metric since we need to collect a statistically significant sample size before reporting NPS for a server version. Based on historical data, ~2000 unique user responses (~1.5-2 months post-ship) are required for the NPS of a particular server version to stabilize. 
 
-NPS by server version can be volatile since it can be affected by the upgrade cadence of heavy usage servers. We typically see a surge in responses when surveys are triggered (21 days after server upgrade) for servers with large DAU, which can impact the NPS trend for that server version. Quarterly trailing NPS is not as affected by this since the sample size is larger and responses are submitted on various server versions. 
+NPS by Server Version can be volatile since it can be affected by the upgrade cadence of heavy usage servers. We typically see a surge in responses when surveys are triggered (21 days after server upgrade) for servers with large DAU, which can impact the NPS trend for that server version. Quarterly trailing NPS is not as affected by this since the sample size is larger and responses are submitted on various server versions. 
 
 ### Written Response Feedback
 

--- a/operations/business-operations/analytics/metrics-definitions.md
+++ b/operations/business-operations/analytics/metrics-definitions.md
@@ -243,7 +243,7 @@ Based on the above calculation method, we can apply a time window (Quarterly Tra
 
 NPS by Server Version is a lagging metric since we need to collect a statistically significant sample size before reporting NPS for a server version. Based on histroical data, ~2000 unique user responses (~1.5-2 months post-ship) are required for the NPS of a particular server version to stabilize. 
 
-NPS by server version can be volatile since it can be affected by the upgrade cadence of heavy usage servers. We typically see a surge in responses when surveys are triggered (21 days after server upgrade) for servers with large DAU that can impact the NPS trend for that server version. Quarterly trailing NPS is not as affected by this since the sample size is larger and responses are submitted on various server versions. 
+NPS by server version can be volatile since it can be affected by the upgrade cadence of heavy usage servers. We typically see a surge in responses when surveys are triggered (21 days after server upgrade) for servers with large DAU, which can impact the NPS trend for that server version. Quarterly trailing NPS is not as affected by this since the sample size is larger and responses are submitted on various server versions. 
 
 ### Written Response Feedback
 

--- a/operations/business-operations/analytics/metrics-definitions.md
+++ b/operations/business-operations/analytics/metrics-definitions.md
@@ -247,12 +247,12 @@ NPS by Server Version can be volatile since it can be affected by the upgrade ca
 
 ### Written Response Feedback
 
-Users can optionally submit written responses to the NPS survey. These responses are reviewed and categorized by the PM team to allow us to [stack rank](https://docs.google.com/spreadsheets/d/1cWqg_djHd_Xmq7cuG0YZj-lKmafgCHU_dU4KfRkClrY/edit#gid=0) certain initiatives for roadmap planning based on their impact to NPS, reach and effort to design, implement and test.
+Users can optionally submit written responses to the NPS survey. These responses are reviewed and categorized by the PM team to allow us to stack rank certain initiatives for roadmap planning based on their impact to NPS, reach and effort to design, implement and test.
 
 To determine impact to NPS, we can:
 1. Segment the reponses based on written feedback from users who are detractors or passives (See the NPS Feedback section of the [NPS dashboard](https://mattermost.looker.com/dashboards/147))
-2. Segment the responses based on the feedback category to analyze [what requested product enhancements equate to the lowest NPS scores from users](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=1937727547).
-3. View overall [number of responses by feedback category](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=831069489).
+2. Segment the responses based on the feedback category to analyze what requested product enhancements equate to the lowest NPS scores from users
+3. View overall number of responses by feedback category
 
 
 ## Sales

--- a/operations/business-operations/analytics/metrics-definitions.md
+++ b/operations/business-operations/analytics/metrics-definitions.md
@@ -247,11 +247,11 @@ NPS by server version can be volatile since it can be affected by the upgrade ca
 
 ### Written Response Feedback
 
-Users can optionally submit written responses to the NPS survey. These responses are reviewed and categorized by the PM team to allow us to [stack rank](https://docs.google.com/spreadsheets/d/1cWqg_djHd_Xmq7cuG0YZj-lKmafgCHU_dU4KfRkClrY/edit#gid=0) certain initiatives for roadmap planning based on their impact to NPS, reach and effort to design, implement and test. 
+Users can optionally submit written responses to the NPS survey. These responses are reviewed and categorized by the PM team to allow us to [stack rank](https://docs.google.com/spreadsheets/d/1cWqg_djHd_Xmq7cuG0YZj-lKmafgCHU_dU4KfRkClrY/edit#gid=0) certain initiatives for roadmap planning based on their impact to NPS, reach and effort to design, implement and test.
 
 To determine impact to NPS, we can:
-1. Segment the reponses based written feedback from users who are detractors or passives (See the NPS Feedback section of the [NPS dashboard](https://mattermost.looker.com/dashboards/147))
-2. Segment the responses based on the categorization of the written feedback to analyze [what requested product enhancements equate to the lowest NPS scores from users](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=1937727547).
+1. Segment the reponses based on written feedback from users who are detractors or passives (See the NPS Feedback section of the [NPS dashboard](https://mattermost.looker.com/dashboards/147))
+2. Segment the responses based on the feedback category to analyze [what requested product enhancements equate to the lowest NPS scores from users](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=1937727547).
 3. View overall [number of responses by feedback category](https://docs.google.com/spreadsheets/d/1g6Uv5BHm54TEnXfUPBFzj_IYysqxUMt3ifgdemRPAKU/edit#gid=831069489).
 
 


### PR DESCRIPTION
Update NPS metric definitions and include links to the new NPS dashboard:
https://mattermost.looker.com/dashboards/147

This PR introduces the definitions for "Quarterly Trailing NPS" and "NPS by Server Version" which are the primary methods of computing NPS used by the product team and represent the state of NPS for our customers.

New dashboard and metric definitions have been reviewed and approved by Lindsay and shared with PM team.

Note: Opening a new PR for these changes as the original PR was merged and reverted in error: https://github.com/mattermost/mattermost-handbook/pull/240