### PR TITLE
Update release checklists

### DIFF
--- a/operations/research-and-development/product/release-process/bug-fix-release.md
+++ b/operations/research-and-development/product/release-process/bug-fix-release.md
@@ -256,7 +256,7 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
         - The week before code complete:
             - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
-         - The week before code complete:
+         - The week before code complete (one for Apps and for Mobile):
             - If an existing ESR is going out of support next month, update the in-app prompts (mobile and desktop) to start detecting for the new minimum supported ESR version
             - If a new ESR is released next month, update the prompts to recommend upgrading to that version instead of the older ESR
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)

--- a/operations/research-and-development/product/release-process/bug-fix-release.md
+++ b/operations/research-and-development/product/release-process/bug-fix-release.md
@@ -254,8 +254,11 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - Upgrade dependancies for webapp, server, and Redux
         - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
-        - The week of code complete:
+        - The week before code complete:
             - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
+         - The week before code complete:
+            - If an existing ESR is going out of support next month, update the in-app prompts (mobile and desktop) to start detecting for the new minimum supported ESR version
+            - If a new ESR is released next month, update the prompts to recommend upgrading to that version instead of the older ESR
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](https://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/ist-dsi/mattermost-cookbook/issues/22).

--- a/operations/research-and-development/product/release-process/feature-release.md
+++ b/operations/research-and-development/product/release-process/feature-release.md
@@ -294,7 +294,7 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
        - The week before code complete:
             - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
-        - The week before code complete:
+        - The week before code complete (one for Apps and for Mobile):
             - If an existing ESR is going out of support next month, update the in-app prompts (mobile and desktop) to start detecting for the new minimum supported ESR version
             - If a new ESR is released next month, update the prompts to recommend upgrading to that version instead of the older ESR
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)

--- a/operations/research-and-development/product/release-process/feature-release.md
+++ b/operations/research-and-development/product/release-process/feature-release.md
@@ -292,8 +292,11 @@ The final release is cut - RC cuts and bug fixes should be completed by this dat
             - [NPM updates](https://mattermost.atlassian.net/browse/MM-24659)
        - Week after release (for GitLab dev owner)
             - [Submit GitLab Omnibus RC install of Mattermost](https://mattermost.atlassian.net/browse/MM-9872)
-       - The week of code complete:
+       - The week before code complete:
             - [Add telemetry for new configuration settings in the release](https://mattermost.atlassian.net/browse/MM-24483)
+        - The week before code complete:
+            - If an existing ESR is going out of support next month, update the in-app prompts (mobile and desktop) to start detecting for the new minimum supported ESR version
+            - If a new ESR is released next month, update the prompts to recommend upgrading to that version instead of the older ESR
     - Confirm that [mattermost-docker](https://github.com/mattermost/mattermost-docker/releases) has been updated to the latest version (contact the maintainer via direct message on community server if necessary)
     - Contact owners of [community installers](http://www.mattermost.org/installation/) or submit PRs to update install version number
       - For Chef Cookbook, open a new issue to announce the new release. See [example](https://github.com/ist-dsi/mattermost-cookbook/issues/22)


### PR DESCRIPTION
- Add a checklist to the ESR process that when an existing ESR goes out of support we need to update the in-app prompts (mobile and desktop) to start detecting for the new minimum supported ESR version
- Also when a new ESR is released we should update the prompts to recommend upgrading to that version instead of the older ESR (since each ESR has overlapping support windows with the previous ESR)