### PR TITLE
Add response writing tips to community response policy

### DIFF
--- a/operations/operations/company-policies/community-response-policy.md
+++ b/operations/operations/company-policies/community-response-policy.md
@@ -72,7 +72,7 @@ While anyone can escalate a sensitive topic, only approved responders listed bel
 
 Non-sensitive topics include feature requests, troubleshooting questions, bug reports, and other user feedback.
 
-Anyone in the company is welcome and encouraged to respond, regardless of the medium. If it is your first time responding to the community, please read [principles, tips and sample responses](https://docs.mattermost.com/process/community-guidelines.html#mattermost-community-forums) for help on various inquiries.
+Anyone in the company is welcome and encouraged to respond, regardless of the medium. If it is your first time responding to the community, please read [principles, tips, and sample responses](https://docs.mattermost.com/process/community-guidelines.html#mattermost-community-forums) for help on various inquiries.
 
 ### Response writing tips
 

--- a/operations/operations/company-policies/community-response-policy.md
+++ b/operations/operations/company-policies/community-response-policy.md
@@ -27,52 +27,72 @@ Raising an issue is the responsibility of whoever is managing community response
 While anyone can escalate a sensitive topic, only approved responders listed below can engage. If you’d like to be an approved responder for one or more of the topics, we welcome the help! Reach out to @jason.blais on community.mattermost.com, and you will be added to the next training session.
 
 1. Non-regulatory **Privacy/Telemetry** where opinions are at play more than legal or regulatory issues:
-* Approved Responders: Head of Community, Lead PM, CPO, CEO
-* Loop in: CEO
-* Template Response: To be added
+ * Approved Responders: Head of Community, Lead PM, CPO, CEO
+ * Loop in: CEO
+ * Template Response: To be added
 
 2. Product-related **Regulations/GDPR**, and other legal issues:
-* Approved Responders: Head of Community, Lead PM, Head of Legal, CPO, CEO
-* Loop in: Head of Legal, Lead PM
-* Template Response: To be added
+ * Approved Responders: Head of Community, Lead PM, Head of Legal, CPO, CEO
+ * Loop in: Head of Legal, Lead PM
+ * Template Response: To be added
 
 3. **Licensing**, including open source and commercial license inquiries:
-* Approved Responders: Head of Community, Lead PM, CEO
-* Template Response: To be added
+ * Approved Responders: Head of Community, Lead PM, CEO
+ * Template Response: To be added
 
 4. **Packaging**, including requests for making an Enterprise feature free:
-* Approved Responders: Lead PM, CPO
-* Template Response: To be added
+ * Approved Responders: Lead PM, CPO
+ * Template Response: To be added
 
 5. **Workplace policies**, including hiring locations:
-* Approved Responders: Director of HR, Head of Legal
-* Template Response: To be added
+ * Approved Responders: Director of HR, Head of Legal
+ * Template Response: To be added
 
 6. **Security vulnerabilities**
-* Approved Responders: Head of Community, Head of Security, Security PM, VP Eng
-* Loop in: Head of Security, Security PM, VP Eng
-* Template Response: To be added
+ * Approved Responders: Head of Community, Head of Security, Security PM, VP Eng
+ * Loop in: Head of Security, Security PM, VP Eng
+ * Template Response: To be added
 
 7. **Illicit use**
-* Approved Responders: Head of Community, VP Marketing, CEO
-* Loop in: Head of Legal, VP Marketing
-* Template Response: To be added
+ * Approved Responders: Head of Community, VP Marketing, CEO
+ * Loop in: Head of Legal, VP Marketing
+ * Template Response: To be added
 
 8. Marketing-related **Regulations/GDPR**, and other legal issues:
-* Approved Responders: Head of Community, VP Marketing, Head of Legal, CEO
-* Loop in: VP Marketing, Head of Legal
-* Template Response: To be added
+ * Approved Responders: Head of Community, VP Marketing, Head of Legal, CEO
+ * Loop in: VP Marketing, Head of Legal
+ * Template Response: To be added
 
 9. **Governmental data request**, e.g. US government requesting user/customer data under US jurisdiction:
-* Approved Responders: Head of Legal, CEO
-* Loop in: Head of Legal
-* Template Response: To be added
+ * Approved Responders: Head of Legal, CEO
+ * Loop in: Head of Legal
+ * Template Response: To be added
 
 ### Non-sensitive topics
 
 Non-sensitive topics include feature requests, troubleshooting questions, bug reports, and other user feedback.
 
 Anyone in the company is welcome and encouraged to respond, regardless of the medium. If it is your first time responding to the community, please read [principles, tips and sample responses](https://docs.mattermost.com/process/community-guidelines.html#mattermost-community-forums) for help on various inquiries.
+
+### Response writing tips
+
+- **Don't make false promises or assumptions**
+  - If you are unsure of the answer, ask someone for help. Do not reply with an assumption or incomplete understanding.
+  - Don’t say "we’ll work on feature X" that sets expectations we cannot meet (e.g. after presenting to core team it turns out you can’t implement the feature).
+- **Choose positivity over negativity**
+  - Avoid excuses like “we’re busy”, or “our team is small” and turn a missing feature into an invitation to share a feature idea to be upvoted.
+- **Do your best to link documentation as answers**
+  - Allow answers to be easily updated dynamically, as documentation is updated.
+  - Turn questions that are not answered in docs, but should be, into tickets to create that documentation (and include ticket link in your response).
+- **Keep community end user information secure**
+  - If you come across a post that includes the person's IP address, domain name, or other information you think should not be disclosed publicly, edit the post to remove this information. Then click the **hide revision** button so that your edits won't be visible to others on the forum.
+- **Be thankful**
+  - Communities really respond well to being praised and thanked for their work.
+- **Do not focus on opinions**
+  - Try to understand each person's [emotions, assumptions and priorities](https://handbook.mattermost.com/company/about-mattermost/mindsets#emotion-assumption-and-priority) and shift the conversation away from opinions.
+  - Turn product discussions into conversations of specific audiences and use cases that each product edition serves.
+
+For more guidelines on Mattermost forums and the public GitHub repositories, see the [Mattermost Community Playbook](https://handbook.mattermost.com/contributors/contributors/community-playbook#mattermost-community-forums).
 
 ### Roles
 


### PR DESCRIPTION
WIP: Add response writing tips to community response policy

We should also adjust the section at https://handbook.mattermost.com/contributors/contributors/community-playbook#mattermost-community-forums