### PR TITLE
Update contribution-guidelines.md

### DIFF
--- a/contributors/contributors/contribution-guidelines.md
+++ b/contributors/contributors/contribution-guidelines.md
@@ -1,6 +1,6 @@
 # [Code Contribution Guidelines](https://github.com/mattermost/.github/blob/master/CONTRIBUTING.md)
 
-Thank you for your interest in contributing! Please see the [Mattermost Contribution Guide](https://developers.mattermost.com/contribute/getting-started/) which describes the process for making code contributions across Mattermost projects and [join our "Contributors" community channel](https://community.mattermost.com/core/channels/tickets) to ask questions from community members and the Mattermost core team.
+Thank you for your interest in contributing! Please see the [Mattermost Contribution Guide](https://developers.mattermost.com/contribute/getting-started/) which describes the process for making code contributions across Mattermost projects and [join our Contributors community channel](https://community.mattermost.com/core/channels/tickets) to ask questions from community members and the Mattermost core team.
 
 When you submit a pull request, it goes through a [code review process outlined here](https://developers.mattermost.com/contribute/getting-started/code-review/).
 
@@ -69,6 +69,7 @@ representative at an online or offline event.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
 community@mattermost.com.
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the
@@ -81,19 +82,19 @@ the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
+**Community Impact:** Use of inappropriate language or other behavior deemed
 unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
+**Consequence:** A private written warning from community leaders, providing
 clarity around the nature of the violation and an explanation of why the
 behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
+**Community Impact:** A violation through a single incident or series
 of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
+**Consequence:** A warning with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
@@ -102,10 +103,10 @@ permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
+**Community Impact:** A serious violation of community standards, including
 sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
+**Consequence:** A temporary ban from any sort of interaction or public
 communication with the community for a specified period of time. No public or
 private interaction with the people involved, including unsolicited interaction
 with those enforcing the Code of Conduct, is allowed during this period.
@@ -113,23 +114,21 @@ Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
+**Consequence:** A permanent ban from any sort of public interaction within
 the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org],
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
 Community Impact Guidelines were inspired by [Mozilla's code of conduct
 enforcement ladder](https://github.com/mozilla/diversity).
-
-[homepage]: https://www.contributor-covenant.org
 
 For answers to common questions about this code of conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at

--- a/contributors/contributors/contribution-guidelines.md
+++ b/contributors/contributors/contribution-guidelines.md
@@ -94,7 +94,7 @@ behavior was inappropriate. A public apology may be requested.
 **Community Impact:** A violation through a single incident or series
 of actions.
 
-**Consequence:** A warning with consequences for continued behavior. No
+**Consequence:** A private written warning from community leaders with consequences for continued behavior. No
 interaction with the people involved, including unsolicited interaction with
 those enforcing the Code of Conduct, for a specified period of time. This
 includes avoiding interactions in community spaces as well as external channels
@@ -116,7 +116,7 @@ Violating these terms may lead to a permanent ban.
 
 **Community Impact:** Demonstrating a pattern of violation of community
 standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+individual, aggression toward, or disparagement of, classes of individuals.
 
 **Consequence:** A permanent ban from any sort of public interaction within
 the community.
@@ -127,9 +127,9 @@ This Code of Conduct is adapted from the [Contributor Covenant][https://www.cont
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by [Mozilla's Code of Conduct
+Enforcement Ladder](https://github.com/mozilla/diversity).
 
-For answers to common questions about this code of conduct, see the FAQ at
+For answers to common questions about this Code of Conduct, see the FAQ at
 https://www.contributor-covenant.org/faq. Translations are available at
 https://www.contributor-covenant.org/translations.

--- a/contributors/contributors/contribution-guidelines.md
+++ b/contributors/contributors/contribution-guidelines.md
@@ -123,7 +123,7 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][https://www.contributor-covenant.org],
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
 version 2.0, available at
 https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 


### PR DESCRIPTION
Made minor spacing fix and moved a URL around to open PR and confirm the formatting and header links with author.

@emilyacook, this is awesome, thank you! I opened this PR because:

- I wanted to find out whether the column formatting was intentional before I go in and change it inadvertently. I like the way it looks and can add reference to it in the technical writing style guide if it's how we should style agreements/codes of conduct.

- I wanted to confirm that the first H1 header is meant to go to a GitHub stub here https://github.com/mattermost/.github/blob/master/CONTRIBUTING.md. If so, perhaps we can also add https://mattermost.com/contribute/ as it lists all the areas within which community members can get involved? 

- Alternatively, perhaps we could remove the link as it duplicates the content in that section. 

- Related to that, in the plugin repos we're standardizing the README.md file so that the "Development" section contains the same content and points to two pages that are intended to be the single source of truth (e.g., https://github.com/mattermost/mattermost-plugin-incident-response#contributing). I'm very open to syncing them up for consistency. For example, having the link to https://mattermost.com/contribute/ across the board. 

- I also added what may have been a missing URL but could also have been intentional. 

- Wondering if we can link to this page from here: https://handbook.mattermost.com/contributors/contributors/community-playbook#getting-the-community-involved-in-a-campaign as well? 

Other than my nit-picking, this is super-helpful! :) 
