### PR TITLE
Update release-overview.md

### DIFF
--- a/operations/research-and-development/product/product-planning/release-plan.md
+++ b/operations/research-and-development/product/product-planning/release-plan.md
@@ -11,7 +11,7 @@ The release plan may include major bugs, smaller features and even tasks require
 When we add items to a release, we are targeting their completion by that release, however, things such as underestimation of work required or quality issues found during testing may prevent it from actually being released.
 
 * If a feature is at risk being cut from a release after it was targeted, we do our best to communicate to all those interested as soon as possible. Typically, the PM team reviews and updates the release plan weekly.
-* If a feature is cut from a release, it is not necessarily put into the next release. There may be unforeseen complications that need to be solved before it can be considered that may take multiple release cycles to address. Other work may be deemed higher priority and it may be deprioritized to be considered later. 
+* If a feature is cut from a release, it is not necessarily put into the next release. There may be unforeseen complications that need to be solved that may take multiple release cycles to address. In some cases, other work may be deemed higher priority and the feature will be deprioritized and considered at a later stage.
 
 PMs will do their best to communicate next steps for features that are cut.
 

--- a/operations/research-and-development/product/product-planning/release-plan.md
+++ b/operations/research-and-development/product/product-planning/release-plan.md
@@ -11,19 +11,17 @@ The release plan may include major bugs, smaller features and even tasks require
 When we add items to a release, we are targeting their completion by that release, however, things such as underestimation of work required or quality issues found during testing may prevent it from actually being released.
 
 * If a feature is at risk being cut from a release after it was targeted, we do our best to communicate to all those interested as soon as possible. Typically, the PM team reviews and updates the release plan weekly.
-* If a feature is cut from a release, it is not necessarily put into the next feature release. There may be unforeseen complications that need to be solved before it can be considered that may take multiple release cycles to address. Other work may be deemed higher priority and it may be deprioritized to be considered later. 
+* If a feature is cut from a release, it is not necessarily put into the next release. There may be unforeseen complications that need to be solved before it can be considered that may take multiple release cycles to address. Other work may be deemed higher priority and it may be deprioritized to be considered later. 
 
 PMs will do their best to communicate next steps for features that are cut.
 
 ## Release Philosophy
 
-We follow a time-based release philosophy. This means we release a new version of our Mattermost product every month on the 16th. On even-numbered months (February, April, June, August, October, and December) we release new features in our product. On odd-numbered months (January, March, May, July, September, and November), we do not release features, but improve the quality and stability of features previously released by only releasing bug fixes. 
+We follow a time-based release philosophy. This means we release a new version of our Mattermost product every month on the 16th.
 
-### Quality Releases
+### Extended Support Releases
 
-We recommend customers who value stability, to upgrade following our quality or odd-numbered releases. Each month’s release includes a [release blog](https://mattermost.com/blog/category/releases/), which highlights features or improvements and updates to our [changelog](https://docs.mattermost.com/administration/changelog.html), where all changes can be viewed for the release.
-
-Our quality releases for January and July, are offered as an [Extended Support Releases (ESR)](https://docs.mattermost.com/administration/extended-support-release.html). This type of release allows customers to receive backports for security fixes and bug fixes without having to upgrade to a version with new functionality that would require significant testing and certification before rolling to large volume of users. We also do dot releases for major bugs and security fixes and backport these to the previous three monthly releases. For more information on our release types and processes please see this [documentation](https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-overview).
+Our releases for January and July are offered as an [Extended Support Releases (ESR)](https://docs.mattermost.com/administration/extended-support-release.html). This type of release allows customers to receive backports for security fixes and bug fixes without having to upgrade to a version with new functionality that would require significant testing and certification before rolling to large volume of users. We also do dot releases for major bugs and security fixes and backport these to the previous three monthly releases. For more information on our release types and processes please see this [documentation](https://handbook.mattermost.com/operations/research-and-development/product/release-process/release-overview).
 
 ## Major Versions
 

--- a/operations/research-and-development/product/release-process/release-overview.md
+++ b/operations/research-and-development/product/release-process/release-overview.md
@@ -1,12 +1,10 @@
 # Release Overview
 
-Mattermost adopts a monthly tick-tock release cycle, with a new version shipping on the 16th of each month in [binary form](http://docs.mattermost.com/administration/upgrade.html#mattermost-team-edition).
+Mattermost ships with a new version on the 16th of each month in [binary form](http://docs.mattermost.com/administration/upgrade.html#mattermost-team-edition).
 
-Tick-tock refers to even-numbered releases (e.g., v5.6) containing new features, and odd-numbered releases (e.g., v5.7) containing only bug fixes and performance improvements.
+For the past few years, Mattermost used a monthly “tick-tock” alternating release cycle. A tick-tock cycle refers to even-numbered releases (e.g., 5.26) containing new features, and odd-numbered releases (e.g., 5.27) containing only bug fixes and performance improvements. As our product and team continue to evolve, we're moving away from this alternating release cycle in favor of a general monthly release.
 
-The primary goal of our release cycle is to improve quality and build trust with our users in every release. A tick-tock release cycle allows new features to soak in our test environments for longer, allowing us to identify and fix bugs before releasing the features.
-
-There is no change to the process or release schedule for security issues. When security issues are found that warrant a patch release, we follow the [security release process outlined here](https://handbook.mattermost.com/operations/research-and-development/product/release-process/security-release).
+When security issues are found that warrant a patch release, we follow the [security release process outlined here](https://handbook.mattermost.com/operations/research-and-development/product/release-process/security-release).
 
 ## Release Numbering
 
@@ -35,37 +33,21 @@ Mattermost numbers stable releases in the following format:
 
 ## Frequently Asked Questions
 
-**Q: Will tick-tock releases delay features?**
-
-  - A: You can view current, near term, and future priorities on [our website here](https://mattermost.com/roadmap/). While tick-tock releases mean only shipping new features every other release, it improves the quality of features shipped. We want to avoid rushing to ship new features and then fixing bugs over a number of releases, and instead we focus on shipping high-quality features out the gate.
-
 **Q: What is the release cycle for the React Native mobile apps?**
 
-  - A: The mobile apps follow the same monthly tick-tock release cycle as Mattermost Server/Webapp, releasing on the 16th of each month.
+  - A: The mobile apps follow the same monthly release cycle as Mattermost Server/Webapp, releasing on the 16th of each month.
 
 **Q: What is the release cycle for the Mattermost Desktop app?**
 
-  - A: Desktop releases are currently released as required. We hope to move Desktop to a more frequent and scheduled release cycle in the near future.
+  - A: Desktop releases are currently released as required.
 
-**Q: When is release branch cut for a quality release?**
+**Q: When is release branch cut for a release?**
 
-  - A: On the day prior feature release ships after final has been cut.
-
-**Q: When is release branch cut for a feature release?**
-
-  - A: On feature cut-off date (T-20).
+  - A: One week prior to the release day.
 
 **Q: How are PRs merged for release?**
 
-  - A: PRs are first merged to master. The dev who submitted the fix is then responsible for cherry-picking it to the quality release branch.
-
-**Q: How are PRs merged for a feature release?**
-
-  - A: PRs are submitted and merged to master (no change).
-
-**Q: How does quality release work?**
-
-  - A: Bugs are branched off from the previous feature release.
+  - A: PRs are first merged to master. The dev who submitted the fix is also responsible for cherry-picking it to the release branch after a release branch has been cut.
 
 **Q: How is cherry-picking done?**
 
@@ -98,15 +80,6 @@ Mattermost numbers stable releases in the following format:
 **Q: How does release team monitor what changes went into a release?**
 
   - A: Monitor the commit history of the respective release branch, e.g., https://github.com/mattermost/mattermost-server/commits/release-5.4 contains commits that shipped with mattermost-server v5.4. Jira ticket is resolved after cherry picking is done.
-
-**Q: What changes were made to the dev release process to account for the rotating feature and quality releases?**
-
-  - A: See https://developers.mattermost.com/internal/release-process/. A PR with changes was merged
-    [here](https://github.com/mattermost/mattermost-developer-documentation/pull/182).
-
-**Q: What changes were made to the team release process to account for the rotating feature and quality releases?**
-
-  - A: Separate checklists for [Quality release](https://handbook.mattermost.com/operations/research-and-development/product/release-process/bug-fix-release) and [Feature release](https://handbook.mattermost.com/operations/research-and-development/product/release-process/feature-release) were created.
 
 **Q: How does translations branching work?**
 


### PR DESCRIPTION
- Update some docs to remove references to the tick-tock release cadence as we're moving away from that in the short-term.