### PR TITLE
Update README.md

### DIFF
--- a/contributors/contributors/README.md
+++ b/contributors/contributors/README.md
@@ -8,7 +8,7 @@ description: 0% complete. The Mattermost Handbook
 
 ### Contributors Key Info
 
-* [Taxonomy of Mattermost Contributors](https://docs.mattermost.com/process/community-overview.html)
+* [Taxonomy of Mattermost Contributors](/contributors/contributors/community)
 
 ### FY20 Contributors VPMOM \(TBA\)
 


### PR DESCRIPTION
Replaced a link to docs.mattermost.com which in turn links back to the handbook, to a direct link to the handbook.