### PR TITLE
Add R&D teams to R&D section

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -195,6 +195,7 @@
 
 * [Contributors](contributors/contributors/README.md)
   * [Mattermost Community](contributors/contributors/community.md)
+  * [Core Committers](contributors/contributors/core-committers.md)
   * [Community Systems](contributors/contributors/community-systems.md)
   * [Contribution Guidelines and Code of Conduct](contributors/contributors/contribution-guidelines.md)
   * [Mattermost Community Playbook](contributors/contributors/community-playbook.md)

--- a/contributors/contributors/core-committers.md
+++ b/contributors/contributors/core-committers.md
@@ -1,0 +1,275 @@
+# Core Committers
+
+A core committer is a maintainer on the Mattermost project that has merge access to Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community, and guiding the technical vision of Mattermost. If you have a question or need some help, these are the people to ask.
+
+Below is the list of core committers working on Mattermost:
+
+- **<a name="corey.hulen">Corey Hulen</a>**
+    - @corey on [community.mattermost.com](https://community.mattermost.com/core/messages/@corey) and [@coreyhulen](https://github.com/coreyhulen) on GitHub
+    - Dev areas: High Availability, Orchestration/Kubernetes, Push Proxy, Classic Mobile Apps
+- **<a name="joram.wilander">Joram Wilander</a>**
+    - @joram on [community.mattermost.com](https://community.mattermost.com/core/messages/@joram) and [@jwilander](https://github.com/jwilander) on GitHub
+    - Dev areas: Web App, Redux, REST API, Toolkit, OAuth SSO, Statuses, WebSocket, Licensing, Kubernetes, Performance
+- **<a name="christopher.speller">Christopher Speller</a>**
+    - @christopher on [community.mattermost.com](https://community.mattermost.com/core/messages/@christopher) and [@crspeller](https://github.com/crspeller) on GitHub
+    - Dev areas: Performance, Security, Build, LDAP, Load Tests, Webpack, Permissions, Kubernetes
+- **<a name="harrison.healey">Harrison Healey</a>**
+    - @harrison on [community.mattermost.com](https://community.mattermost.com/core/messages/@harrison) and [@hmhealey](https://github.com/hmhealey) on GitHub
+    - Dev areas: Mobile/Desktop and Web apps
+- **<a name="elias.nahum">Elias Nahum</a>**
+    - @elias on [community.mattermost.com](https://community.mattermost.com/core/messages/@elias) and [@enahum](https://github.com/enahum) on GitHub
+    - Dev areas: Mobile
+- **<a name="george.goldberg">George Goldberg</a>**
+    - @george on [community.mattermost.com](https://community.mattermost.com/core/messages/@george) and [@grundleborg](https://github.com/grundleborg) on GitHub
+    - Dev areas: Import/Export (Slack, Bulk Loading, etc.), Diagnostics/Telemetry, Search, Permissions
+- **<a name="saturnino.abril">Saturnino Abril</a>**
+    - @saturnino on [community.mattermost.com](https://community.mattermost.com/core/messages/@saturnino) and [@saturninoabril](https://github.com/saturninoabril) on GitHub
+    - Dev areas: Web App, Redux, React Native, REST API, UI Tests
+- **<a name="chris.duarte">Chris Duarte</a>**
+    - @uberchris on [community.mattermost.com](https://community.mattermost.com/core/messages/@uberchris) and [@csduarte](https://github.com/csduarte) on GitHub
+- **<a name="carlos.panato">Carlos Panato</a>**
+    - @cpanato on [community.mattermost.com](https://community.mattermost.com/core/messages/@cpanato) and [@cpanato](https://github.com/cpanato) on GitHub
+    - Dev areas: REST API, WebSocket Events, Kubernetes, Infrastructure, Build/Releases
+- **<a name="martin.kraft">Martin Kraft</a>**
+    - @martin.kraft on [community.mattermost.com](https://community.mattermost.com/core/messages/@martin.kraft) and [@mkraft](https://github.com/mkraft) on GitHub
+    - Dev areas: Permissions, Compliance, LDAP, Groups, Data Retention
+- **<a name="jesús.espino">Jesús Espino</a>**
+    - @jesus.espino on [community.mattermost.com](https://community.mattermost.com/core/messages/@jesus.espino) and [@jespino](https://github.com/jespino) on GitHub
+    - Dev areas: Web App, Permissions, Compliance, Redux, CLI, System Console, Sample Data
+- **<a name="jesse.hallam">Jesse Hallam</a>**
+    - @jesse.hallam on [community.mattermost.com](https://community.mattermost.com/core/messages/@jesse.hallam) and [@lieut-data](https://github.com/lieut-data) on GitHub
+    - Dev areas: Performance, Web App, Database, Toolkit
+- **<a name="hyeseong.kim">Hyeseong Kim</a>**
+    - @cometkim on [community.mattermost.com](https://community.mattermost.com/core/messages/@cometkim) and [@cometkim](https://github.com/cometkim) on GitHub
+    - Dev areas: Web App, React, Redux, REST API
+- **<a name="ben.schumacher">Ben Schumacher</a>**
+    - @hanzei on [community.mattermost.com](https://community.mattermost.com/core/messages/@hanzei) and [@hanzei](https://github.com/hanzei) on GitHub
+    - Dev areas: Toolkit, Plugins, Community
+- **<a name="lev.brouk">Lev Brouk</a>**
+    - @lev.brouk on [community.mattermost.com](https://community.mattermost.com/core/messages/@lev.brouk) and [@levb](https://github.com/levb) on GitHub
+    - Dev areas: Extensions
+- **<a name="william.gathoye">William Gathoye</a>**
+    - @wget on [community.mattermost.com](https://community.mattermost.com/core/messages/@wget) and [@wget](https://github.com/wget) on GitHub
+    - Dev areas: Desktop app, Plugins
+- **<a name="dean.whillier">Dean Whillier</a>**
+    - @deanwhillier on [community.mattermost.com](https://community.mattermost.com/core/messages/@deanwhillier) and [@deanwhillier](https://github.com/deanwhillier) on GitHub
+    - Dev areas: Desktop/Web and Mobile apps
+- **<a name="miguel.alatzar">Miguel Alatzar</a>**
+    - @miguel.alatzar on [community.mattermost.com](https://community.mattermost.com/core/messages/@miguel.alatzar) and [@migbot](https://github.com/migbot) on GitHub
+    - Dev areas: Mobile
+- **<a name="Miguel de la Cruz">Miguel de la Cruz</a>**
+    - @miguel.delacruz on [community.mattermost.com](https://community.mattermost.com/core/messages/@miguel.delacruz) and [@mgdelacroix](https://github.com/mgdelacroix) on GitHub
+    - Dev areas: Elasticsearch, Web App, Server
+- **<a name="gabe.jackson">Gabe Jackson</a>**
+    - @gabe.jackson on [community.mattermost.com](https://community.mattermost.com/core/messages/@gabe.jackson) and [@gabrieljackson](https://github.com/gabrieljackson) on GitHub
+    - Dev areas: Server, Cloud, Kubernetes
+- **<a name="jason.frerich">Jason Frerich</a>**
+    - @jason.frerich on [community.mattermost.com](https://community.mattermost.com/core/messages/@jason.frerich) and [@jfrerich](https://github.com/jfrerich) on GitHub
+    - Dev areas: Extensions
+- **<a name="stylianos.rigas">Stylianos Rigas</a>**
+    - @stylianos.rigas on [community.mattermost.com](https://community.mattermost.com/core/messages/@jason.frerich) and [@stylianosrigas](https://github.com/stylianosrigas) on GitHub
+    - Dev areas: Kubernetes, Helm, Infrastructure
+- **<a name="christopher.poile">Christopher Poile</a>**
+    - @christopher.poile on [community.mattermost.com](https://community.mattermost.com/core/messages/@christopher.poile) and [@cpoile](https://github.com/cpoile) on GitHub
+    - Dev areas: Extensions
+- **<a name="michael.kochell">Michael Kochell</a>**
+    - @michael.kochell on [community.mattermost.com](https://community.mattermost.com/core/messages/@michael.kochell) and [@mickmister](https://github.com/mickmister) on GitHub
+    - Dev areas: Extensions
+- **<a name="maria.nunez">Maria Nuñez</a>**
+    - @maria.nunez on [community.mattermost.com](https://community.mattermost.com/core/messages/@maria.nunez) and [@marianunez](https://github.com/marianunez) on GitHub
+    - Dev areas: Toolkit, Plugins, Web App
+- **<a name="devin.binnie">Devin Binnie</a>**
+    - @devin.binnie on [community.mattermost.com](https://community.mattermost.com/core/messages/@devin.binnie) and [@devinbinnie](https://github.com/devinbinnie) on GitHub
+    - Dev areas: Desktop/Web and Mobile apps
+- **<a name="guillermo.vaya">Guillermo Vayá</a>**
+    - @guillermo.vaya on [community.mattermost.com](https://community.mattermost.com/core/messages/@guillermo.vaya) and [@Willyfrog](https://github.com/Willyfrog) on GitHub
+    - Dev areas: Web/Desktop apps
+- **<a name="shota.gvinepadze">Shota Gvinepadze</a>**
+    - @shota.gvinepadze on [community.mattermost.com](https://community.mattermost.com/core/messages/@shota.gvinepadze) and [@iomodo](https://github.com/iomodo) on GitHub
+    - Dev areas: Toolkit, Plugins, AI, Machine Learning
+- **<a name="claudio.costa">Claudio Costa</a>**
+    - @claudio.costa on [community.mattermost.com](https://community.mattermost.com/core/messages/@claudio.costa) and [@streamer45](https://github.com/streamer45) on GitHub
+    - Dev areas: Server, Load Tests, Performance, Race Conditions, Multimedia
+- **<a name="scott.bishel">Scott Bishel</a>**
+    - @scott.bishel on [community.mattermost.com](https://community.mattermost.com/core/messages/@scott.bishel) and [@sbishel](https://github.com/sbishel) on GitHub
+    - Dev areas: Permissions, Compliance, LDAP
+- **<a name="hossein.ahmadian">Hossein Ahmadian</a>**
+    - @hossein.ahmadian on [community.mattermost.com](https://community.mattermost.com/core/messages/@hossein.ahmadian) and [@hahmadia](https://github.com/hahmadia) on GitHub
+    - Dev areas: Permissions, Compliance, LDAP
+- **<a name="catalin.tomai">Catalin Tomai</a>**
+    - @catalin.tomai on [community.mattermost.com](https://community.mattermost.com/core/messages/@catalin.tomai) and [@catalintomai](https://github.com/catalintomai) on GitHub
+    - Dev areas: Permissions, Compliance, LDAP
+- **<a name="ian.whitlock">Ian Whitlock</a>**
+     - @ian.whitlock on [community.mattermost.com](https://community.mattermost.com/core/messages/@ian.whitlock) and [@gigawhitlocks](https://github.com/gigawhitlocks) on GitHub
+    - Dev areas: Cloud
+- **<a name="mario.de.frutos">Mario de Frutos</a>**
+    - @mario.de.frutos on [community.mattermost.com](https://community.mattermost.com/core/messages/@mario.de.frutos) and [@ethervoid](https://github.com/ethervoid) on GitHub
+    - Dev areas: Server, Load Tests
+- **<a name="agniva.de.sarker">Agniva De Sarker</a>**
+    - @agniva.de.sarker on [community.mattermost.com](https://community.mattermost.com/core/messages/@agniva.de.sarker) and [@agnivade](https://github.com/agnivade) on GitHub
+    - Dev areas: Performance, Load Tests, Go internals
+- **<a name="chris.overton">Chris Overton</a>**
+    - @chris.overton on [community.mattermost.com](https://community.mattermost.com/core/messages/@chris.overton) and [@chris-overton](https://github.com/chris-overton) on GitHub
+    - Dev areas: Cloud, Elasticsearch, REST API, Kubernetes
+- **<a name="amit.uttam">Amit Uttam</a>**
+    - @amit.uttam on [community.mattermost.com](https://community.mattermost.com/core/messages/@amit.uttam) and [@chuttam](https://github.com/chuttam) on GitHub
+    - Dev areas: Mobile
+- **<a name="doug.lauder">Doug Lauder</a>**
+    - @doug.lauder on [community.mattermost.com](https://community.mattermost.com/core/messages/@doug.lauder) and [@wiggin77](https://github.com/wiggin77) on GitHub
+    - Dev areas: TBA
+- **<a name="ibrahim.acikgoz">Ibrahim Acikgoz</a>**
+    - @ibrahim.acikgoz on [community.mattermost.com](https://community.mattermost.com/core/messages/@ibrahim.acikgoz) and [@isacikgoz](https://github.com/isacikgoz) on GitHub
+    - Dev areas: Backend, CLI, Performance
+- **<a name="nevy.angelova">Nevy Angelova</a>**
+    - @nevyana on [community.mattermost.com](https://community.mattermost.com/core/messages/@nevyana) and [@nevyangelova](https://github.com/nevyangelova) on GitHub
+    - Dev areas: Web App, React, Redux
+- **<a name="alejandro.garcia.montoro">Alejandro García Montoro</a>**
+    - @alejandro.garcia on [community.mattermost.com](https://community.mattermost.com/core/messages/@alejandro.garcia) and [@agarciamontoro](https://github.com/agarciamontoro) on GitHub
+    - Dev areas: Toolkit, Plugins, Server
+- **<a name="angelos.kyratzakos">Angelos Kyratzakos</a>**
+    - @angelos.kyratzakos on [community.mattermost.com](https://community.mattermost.com/core/messages/@angelos.kyratzakos) and [@angeloskyratzakos](https://github.com/angeloskyratzakos) on GitHub
+    - Dev areas: Kubernetes, Infrastructure
+- **<a name="daniel.espino.garcia">Daniel Espino García</a>**
+    - @daniel.espino.garcia on [community.mattermost.com](https://community.mattermost.com/core/messages/@daniel.espino.garcia) and [@larkox](https://github.com/larkox) on GitHub
+    - Dev areas: Extensions
+- **<a name="caleb.roseland">Caleb Roseland</a>**
+    - @caleb.roseland on [community.mattermost.com](https://community.mattermost.com/core/messages/@caleb.roseland) and [@calebroseland](https://github.com/calebroseland) on GitHub
+    - Dev areas: Desktop/Web apps
+- **<a name="avasconcelos114">Andre Vasconcelos</a>**
+    - @avasconcelos114 on [community.mattermost.com](https://community.mattermost.com/core/messages/@avasconcelos114) and [@avasconcelos114](https://github.com/avasconcelos114) on GitHub
+    - Dev areas: Web App, Mobile Apps
+- **<a name="rvillablanca">Rodrigo Villablanca</a>**
+    - @rvillablanca on [community.mattermost.com](https://community.mattermost.com/core/messages/@rvillablanca) and [@rvillablanca](https://github.com/rvillablanca) on GitHub
+    - Dev areas: Server, Store Layer
+- **<a name="shaz.amjad">Shaz Amjad</a>**
+    - @shaz.amjad on [community.mattermost.com](https://community.mattermost.com/core/messages/@shaz.amjad) and [@shazm](https://github.com/shazm) on GitHub
+    - Dev areas: Mobile
+- **<a name="avinash.lingaloo">Avinash Lingaloo</a>**
+    - @avinash.lingaloo on [community.mattermost.com](https://community.mattermost.com/core/messages/@avinash.lingaloo) and [@avinashlng1080](https://github.com/avinashlng1080) on GitHub
+    - Dev areas: Mobile
+- **<a name="collin.eng">Collin Eng</a>**
+    - @collin.eng on [community.mattermost.com](https://community.mattermost.com/core/messages/@collin.eng) and [@engineereng](https://github.com/engineereng) on GitHub
+    - Dev areas: TBD
+
+# Core Developers
+
+Below is the list of core developers working on individual Mattermost repositories:
+
+- **<a name="yuya.ochiai">Yuya Ochiai</a>** - [desktop](https://github.com/mattermost/desktop)
+    - @yuya-oc on [community.mattermost.com](https://community.mattermost.com/core/messages/@yuya-oc) and [@yuya-oc](https://github.com/yuya-oc) on GitHub
+- **<a name="pan.luo">Pan Luo</a>** - [mattermost-docker](https://github.com/mattermost/mattermost-docker)
+    - @compass on [community.mattermost.com](https://community.mattermost.com/core/messages/@compass) and [@xcompass](https://github.com/xcompass) on GitHub
+- **<a name="kyâne.pichou">Kyâne Pichou</a>** - [mattermost-docker](https://github.com/mattermost/mattermost-docker)
+    - @pichouk on [community.mattermost.com](https://community.mattermost.com/core/messages/@pichouk) and [@pichouk](https://github.com/pichouk) on GitHub
+
+# Community Moderators
+
+Below is the list of community moderators who share feedback and answer questions on Mattermost through [forums](https://forum.mattermost.org), GitHub issues and the [Mattermost community server](https://community.mattermost.com):
+
+- **<a name="arlindo.neto">Arlindo Neto</a>**
+    - @prixone on [community.mattermost.com](https://community.mattermost.com/core/messages/@prixone) and [@prixone](https://github.com/prixone) on GitHub
+- **<a name="christopher.parker">Christopher Parker</a>**
+    - @sousapro on [community.mattermost.com](https://community.mattermost.com/core/messages/@sousapro) and [@Sousapro](https://forum.mattermost.org/u/sousapro/summary) on Forum
+- **<a name="ahmad.danial">Ahmad Danial</a>**
+    - @ahmaddanial on [community.mattermost.com](https://community.mattermost.com/core/messages/@ahmaddanial) and [@dannymohammad](https://github.com/dannymohammad) on GitHub
+
+# Product Managers
+
+The core team also has Product Managers who do a lot of great work designing, prioritizing and coordinating. They are:
+
+- **<a name="jason.blais">Jason Blais</a>**
+    - @jason on [community.mattermost.com](https://community.mattermost.com/core/messages/@jason) and [@jasonblais](https://github.com/jasonblais) on GitHub
+- **<a name="eric.sethna">Eric Sethna</a>**
+    - @eric on [community.mattermost.com](https://community.mattermost.com/core/messages/@eric) and [@esethna](https://github.com/esethna) on GitHub
+- **<a name="katie.wiersgalla">Katie Wiersgalla</a>**
+    - @katie.wiersgalla on [community.mattermost.com](https://community.mattermost.com/core/messages/@katie.wiersgalla) and [@wiersgallak](https://github.com/wiersgallak) on GitHub
+- **<a name="aaron.rothschild">Aaron Rothschild</a>**
+    - @aaron.rothschild on [community.mattermost.com](https://community.mattermost.com/core/messages/@aaron.rothschild) and [@aaronrothschild](https://github.com/aaronrothschild) on GitHub
+- **<a name="ian.tao">Ian Tao</a>**
+    - @tao on [community.mattermost.com](https://community.mattermost.com/core/messages/@tao) and [@itao](https://github.com/itao) on GitHub
+
+# Release Managers
+
+The core team also has release managers who help with prioritization and coordination. They are:
+
+- **<a name="amy.blais">Amy Blais</a>**
+    - @amyblais on [community.mattermost.com](https://community.mattermost.com/core/messages/@amyblais) and [@amyblais](https://github.com/amyblais) on GitHub
+
+# QA Testers
+
+The core team also has QA testers who verify the correct functionality of the product from release to release. They are:
+
+- **<a name="linda.mitchell">Linda Mitchell</a>**
+    - @linda on [community.mattermost.com](https://community.mattermost.com/core/messages/@linda) and [@lindalumitchell](https://github.com/lindalumitchell) on GitHub
+- **<a name="lindy.isherwood">Lindy Isherwood</a>**
+    - @lindy.isherwood on [community.mattermost.com](https://community.mattermost.com/core/messages/@lindy.isherwood) and [@lindy65](https://github.com/lindy65) on GitHub
+- **<a name="dylan.haussermann">Dylan Haussermann</a>**
+    - @dylan.haussermann on [community.mattermost.com](https://community.mattermost.com/core/messages/@dylan.haussermann) and [@DHaussermann](https://github.com/DHaussermann) on GitHub
+- **<a name="ogi.marušić">Ogi Marušić</a>**
+    - @ogi.marusic on [community.mattermost.com](https://community.mattermost.com/core/messages/@ogi.marusic) and [@ogi-m](https://github.com/ogi-m) on GitHub
+- **<a name="prapti.shrestha">Prapti Shrestha</a>**
+    - @prapti.shrestha on [community.mattermost.com](https://community.mattermost.com/core/messages/@prapti.shrestha) and [@prapti](https://github.com/prapti) on GitHub
+- **<a name="jelena.gilliam">Jelena Gilliam</a>**
+    - @jelena.gilliam on [community.mattermost.com](https://community.mattermost.com/core/messages/@jelena.gilliam) and [@jgilliam17](https://github.com/jgilliam17) on GitHub
+- **<a name="steve.mudie">Steve Mudie</a>**
+    - @steve.mudie on [community.mattermost.com](https://community.mattermost.com/core/messages/@steve.mudie) and [@stevemudie](https://github.com/stevemudie) on GitHub
+- **<a name="joseph.baylon">Joseph Baylon</a>**
+    - @joseph.baylon on [community.mattermost.com](https://community.mattermost.com/core/messages/@joseph.baylon) and [@josephbaylon](https://github.com/josephbaylon) on GitHub
+
+# Build Engineers
+
+- **<a name="elisabeth.kulzer">Elisabeth Kulzer</a>**
+    - @elisabeth.kulzer on [community.mattermost.com](https://community.mattermost.com/core/messages/@elisabeth.kulzer) and [@metanerd](https://github.com/metanerd) on GitHub
+    
+# Security Engineers
+
+- **<a name="daniel.schalla">Daniel Schalla</a>**
+    - @dschalla on [community.mattermost.com](https://community.mattermost.com/core/messages/@dschalla) and [@dschalla](https://github.com/dschalla) on GitHub
+    - Dev areas: Security, Plugins, Integrations, Performance
+- **<a name="juho.nurminen">Juho Nurminen</a>**
+    - @juho.nurminen on [community.mattermost.com](https://community.mattermost.com/core/messages/@juho.nurminen) and [@jupenur](https://github.com/jupenur) on GitHub
+    - Dev areas: Security
+- **<a name="corey.robinson">Corey Robinson</a>**
+    - @corey.robinson on [community.mattermost.com](https://community.mattermost.com/core/messages/@corey.robinson) and [@corey-robinson](https://github.com/corey-robinson) on GitHub
+    - Dev areas: Security
+- **<a name="rohitesh.gupta">Rohitesh Gupta</a>**
+    - @rohitesh.gupta on [community.mattermost.com](https://community.mattermost.com/core/messages/@rohitesh.gupta) and [@srkgupta](https://github.com/srkgupta) on GitHub
+    - Dev areas: Security
+
+# Technical Writers
+
+The core team also has technical writers who document product features and functionality from release to release, along with product managers. They are:
+
+- **<a name="justine.geffen">Justine Geffen</a>**
+    - @justine.geffen on [community.mattermost.com](https://community.mattermost.com/core/messages/@justine.geffen) and [@justinegeffen](https://github.com/justinegeffen) on GitHub
+- **<a name="carrie.warner">Carrie Warner</a>**
+    - @carrie.warner on [community.mattermost.com](https://community.mattermost.com/core/messages/@carrie.warner) and [@cwarnermm](https://github.com/cwarnermm) on GitHub
+
+# How to promote a contributor to core committer
+
+1. Identify a core committer
+ - A core committer is a maintainer on the Mattermost project and has merge access to Mattermost repositories. They are responsible for reviewing pull requests, cultivating the Mattermost developer community, and guiding the technical vision of Mattermost. If you have a question or need some help, these are the people to ask.
+ - If you feel someone in the community would be interested in such activities, then they may be a great candidate for being promoted to a core committer!
+
+2. Nominate a core committer
+ - If the nomination is for the Mattermost project, or for a core repository (e.g. `mattermost-server`, `mattermost-webapp`), raise the topic in weekly developers meeting.
+ - If the nomination is for a repository managed by a specific team (e.g. `mattermost-plugin-jira`), raise the topic with that team.
+
+3. Team discussed nomination
+ - During the meeting, the nomination is discussed. Meeting participants should feel empowered to raise concerns, if any, on the nomination (e.g. length of involvement in the community, skill sets).
+ 
+4. If the nomination is agreed on, the person who nominated the contributor reaches out to them
+ - The promotion should be opt-in, and the contributor should feel empowered to decline the promotion if they choose.
+
+5. If the contributor accepts the nomination, they are 
+ - Given merge access in the respective GitHub repositories.
+ - Added to the [Mattermost GitHub organization](https://github.com/orgs/mattermost/people), which is displayed in their GitHub profile.
+ - Able to be added as reviewers to relevant pull requests, to offer technical guidance and reviews.
+
+6. The promotion is announced (details TBD)
+ - The new core committer is added to to the above list of core committers.
+ - ...
+
+7. The new core committer is gifted with lot of :heart: and lot of swag :tada: (details TBD)
+ - Core committer mug.
+ - ...

--- a/operations/research-and-development/README.md
+++ b/operations/research-and-development/README.md
@@ -2,6 +2,167 @@
 
 R&D includes engineering, QA, product management, and design \(UX, UI\)
 
+## Leadership
+
+* Corey Hulen - CTO, Head of Product
+* Chris Overton - VP Engineering
+
+### Messaging
+
+#### Leadership
+
+* Joram Wilander - Senior Engineering Lead
+* Katie Wiersgalla - Senior Product Manager Lead
+
+#### Product Managers
+
+* Eric Sethna - Product Manager
+* Aaron Rothschild - Product Manager
+
+#### Technical Writers
+
+* Carrie Warner - Senior Technical Writer
+
+#### Full Stack 1 (name TBD)
+
+* Catalin Tomai - Engineering Lead
+* Martin Kraft - Engineer
+* Claudio Costa - Engineer
+* Shaz Amjad - Engineer
+* Benjamin Cooke - Engineer
+* Furqan Malik - SDET
+
+#### Full Stack 2 (name TBD)
+
+* Catalin Tomai - Engineering Lead
+* Lev Brouk - Engineer
+* Michael Kochell - Engineer
+* Daniel Espino Garcia - Engineer
+* Ben Schumacher - Engineer
+* Jason Frerich - Engineer
+* Dylan Haussermann - QA
+* Matt Birtch - UX Designer
+
+#### Full Stack 3 (name TBD)
+
+* Joram Wilander - Engineering Lead
+* Ashish Bhate - Engineer
+* Anurag Shivarathri - Engineer
+* Kyriakos Ziakoulis - Engineer
+* Jelena Gilliam - QA
+
+#### Web Platform
+
+* Joram Wilander - Engineering Lead
+* Harrison Healey - Engineer
+* Devin Binnie - Engineer
+* Guillermo Vaya - Engineer
+
+#### Suite Platform
+
+* Joram Wilander - Engineering Lead
+* Agniva De Sarker - Engineer
+* Ibrahim Acikgoz - Engineer
+
+### Incident Collaboration
+
+* Jesse Hallam - Engineering Lead
+* Christopher Speller - Engineer
+* Christopher Poile - Engineer
+* Alejandro García Montoro - Engineer
+* Caleb Roseland - Engineer
+* Shota Gvinepadze - Engineer
+* Prapti Shrestha - QA SDET
+* Ian Tao - Product Manager
+* Abhijit Singh - UX Designer
+* Justine Geffen - Technical Writer
+
+### Focalboard
+
+* Scott Bishel - Engineering Lead
+* Jesus Espino - Engineer
+* Miguel de la Cruz - Engineer
+* Doug Lauder - Engineer
+* Hossein Ahmadian - Engineer
+* Harshil Sharma - Engineer
+* Ogi Marusic - QA
+* Chen-I Lim - Product Manager
+* Michael Gamble - UX Designer
+* Justine Geffen - Technical Writer
+
+### Cloud
+
+#### Leadership
+
+* Jason Blais - Senior Product Manager Lead
+
+#### Growth Team
+
+* Maria Nuñez - Engineering Lead
+* Allan Guwatudde - Engineer
+* Mario de Frutos - Engineer
+* Pablo Vélez Vidal - Engineer
+* Nick Misasi - Engineer
+* Steve Mudie - QA
+* Anneliese Klein - UX Designer
+* Justine Geffen - Technical Writer
+
+#### Cloud Platform Team
+
+* Gabe Jackson - Engineering Lead
+* Ian Whitlock - Engineer
+* Szymon Gibała - Engineer
+
+### Site Reliability Engineering Team
+
+* Spiros Economakis - Engineering Lead
+* Stylianos Rigas - Engineer
+* Angelos Kyratzakos - Engineer
+* Stavros Foteinopoulos - Engineer
+* Muhammad Shahid - Engineer
+
+### Release/DevOps Team
+
+* Joram Wilander - Engineering Lead
+* Carlos Panato - Engineer
+* Elisabeth Kulzer - Engineer
+* Amy Blais - Release Manager
+
+### Platform Teams
+
+#### Leadership
+
+* Zef Hemel - Engineering Lead
+* Jason Blais - Senior Product Manager Lead
+
+#### Mobile Team
+
+* Elias Nahum - Engineering Lead
+* Miguel Alatzar - Engineer
+* Avinash Lingaloo - Engineer
+* Joseph Baylon - QA SDET
+
+#### QA Team
+
+* Linda Mitchell - QA Lead
+* Saturnino Abril - QA SDET
+* Lindy Isherwood - QA
+
+#### UI Team
+
+* Dean Whillier - Engineering Lead
+* Nevy Angelova - Engineer
+* Michel Engelen - Engineer
+
+## Security Team
+
+* Daniel Schalla - Engineering Lead
+* Juho Nurminen - Product Security Engineer
+* Rohitesh Gupta - Product Security Engineer
+* Corey Robinson - Security Engineer, Infrastructure & Operations
+* Kennedy Torkura - Cloud Security Engineer
+* Katie Wiersgalla - Product Manager
+
 #### R&D Key Info
 
 * [Development & Release Process](https://docs.mattermost.com/guides/core.html#development-process): How open source software is developed

--- a/operations/research-and-development/README.md
+++ b/operations/research-and-development/README.md
@@ -1,6 +1,22 @@
 # Research & Development
 
-R&D includes engineering, QA, product management, and design \(UX, UI\)
+R&D includes engineering, QA, product management, and design \(UX, UI\). 
+
+## R&D Key Info
+
+* [Development & Release Process](https://docs.mattermost.com/guides/core.html#development-process): How open source software is developed
+* [Platform Contribution Process](https://docs.mattermost.com/guides/core.html#community-process): How contributors can get involved
+* [Analytics](https://community.mattermost.com/private-core/channels/analytics-2): Analytics playbook and data wallows
+* [WIP: Feature Idea Flow Chart](https://docs.google.com/drawings/d/1D6KiN31mhNr1A0DGGHOuu6hvS0gpDTFuftnh2yyniNQ/edit): Work-in-progress
+
+**Product Strategy**
+
+* [Analyst Research](https://community.mattermost.com/private-core/channels/analyst-research): Analyst meeting tracker, briefing procedures, research. We are currently Gartner clients.
+* [Compete](https://community.mattermost.com/private-core/channels/compete): Key articles on competitors. Also see [automated feeds from competitor marketing](https://community.mattermost.com/private-core/channels/compete-feeds).
+
+## FY20 R&D VPMOM \(TBA\)
+
+New VPMOM to be added. VPMOM in need of update: [Irresistable Solution and Platform for High Trust Teams](https://docs.google.com/document/d/1Y4pRZEjEop2D42P-Q899R8f4Pg0TJwUBltUFhq7TX_g/edit?ts=5bf740a1#heading=h.2lyyszkcm50h):
 
 ## Leadership
 
@@ -162,20 +178,3 @@ R&D includes engineering, QA, product management, and design \(UX, UI\)
 * Corey Robinson - Security Engineer, Infrastructure & Operations
 * Kennedy Torkura - Cloud Security Engineer
 * Katie Wiersgalla - Product Manager
-
-#### R&D Key Info
-
-* [Development & Release Process](https://docs.mattermost.com/guides/core.html#development-process): How open source software is developed
-* [Platform Contribution Process](https://docs.mattermost.com/guides/core.html#community-process): How contributors can get involved
-* [Analytics](https://community.mattermost.com/private-core/channels/analytics-2): Analytics playbook and data wallows
-* [WIP: Feature Idea Flow Chart](https://docs.google.com/drawings/d/1D6KiN31mhNr1A0DGGHOuu6hvS0gpDTFuftnh2yyniNQ/edit): Work-in-progress
-
-**Product Strategy**
-
-* [Analyst Research](https://community.mattermost.com/private-core/channels/analyst-research): Analyst meeting tracker, briefing procedures, research. We are currently Gartner clients.
-* [Compete](https://community.mattermost.com/private-core/channels/compete): Key articles on competitors. Also see [automated feeds from competitor marketing](https://community.mattermost.com/private-core/channels/compete-feeds).
-
-#### FY20 R&D VPMOM \(TBA\)
-
-New VPMOM to be added. VPMOM in need of update: [Irresistable Solution and Platform for High Trust Teams](https://docs.google.com/document/d/1Y4pRZEjEop2D42P-Q899R8f4Pg0TJwUBltUFhq7TX_g/edit?ts=5bf740a1#heading=h.2lyyszkcm50h):
-


### PR DESCRIPTION
Added R&D teams from developers.mattermost.com

@jasonblais, I am waiting to find out how to set up redirects in Hugo so that I can redirect traffic from these pages on developers.mattermost.com to the handbook. In the interim, once approved, I'll add this in the announcement channel to let everyone know this is the single source of truth going forward. LMK if that works?

The core committers list was added to the Community section as it seemed to fit. 0/5 on where it lives.