### PR TITLE
Update how-to-create-screenshots-and-gifs.md

### DIFF
--- a/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-screenshots-and-gifs.md
+++ b/operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-screenshots-and-gifs.md
@@ -10,59 +10,59 @@ The purpose is to highlight and illustrate the best features of Mattermost user 
 
 When choosing what to highlight in the screenshot, follow this order:
 
-1. An end-user screenshot that best illustrates the feature
-2. Screenshot of System Console or other settings help text
-3. Screenshot of documentation
-4. Screenshot of a code mentioning the feature and/or Mattermost
+1. An end-user screenshot that best illustrates the feature.
+2. Screenshot of System Console or other settings help text.
+3. Screenshot of documentation.
+4. Screenshot of a code mentioning the feature and/or Mattermost.
 
-### Setup Tips
+### Setup tips
 
-* Use the Mattermost Desktop app, which has a nicer border
-* Create a secondary account with \[first.last\]+blah@mattermost.com email address. This makes triggering notifications for yourself easier \(for the screenshot\). You can also use a second browser to login to the second account while taking the screenshot
+* Use the Mattermost Desktop App, which has a nicer border.
+* Create a secondary account with \[first.last\]+blah@mattermost.com email address. This makes triggering notifications for yourself easier \(for the screenshot\). You can also use a second browser to login to the second account while taking the screenshot.
 
 ### Checklist
 
 * **Screen size:**
-  * Size your Mattermost Desktop App or browser to capture a screenshot approximately 900px by 640px, excluding browser navigation
-  * Use default 100% zoom
-  * Tip: Close the right-hand sidebar, and close the team sidebar by leaving all but one team
-* **Font Size:**
-  * All text should have large enough font size so that text is easily readable
+  * Size your Mattermost Desktop App or browser to capture a screenshot approximately 900px by 640px, excluding browser navigation.
+  * Use default 100% zoom.
+  * Tip: Close the right-hand sidebar, and close the team sidebar by leaving all but one team.
+* **Font size:**
+  * All text should have large enough font size so that text is easily readable.
 * **Visuals:**
-  * Profile pictures and real people’s names should be filled out throughout the screenshot
-  * For the profile picture, use either normal-looking Avatars or stock photography from [istockphoto.com](https://www.istockphoto.com/)
-  * Select the default "Mattermost" theme color in **Account Settings > Theme**
-* **Left-hand side:**
-  * Include Favorite, Public, and Private channels on the left-hand side
-  * Make sure that you scroll all the way to the top in the channel list on the left-hand side for the screenshot
-  * You can have a few unreads or mentions visible, but do not include an “unread posts” indicator in the left-hand side
+  * Profile pictures and real people’s names should be filled out throughout the screenshot.
+  * For the profile picture, use either normal-looking Avatars or stock photography from [istockphoto.com](https://www.istockphoto.com/).
+  * Select the default "Mattermost" theme color in **Account Settings > Theme**.
+* **Left-hand sidebar:**
+  * Include Favorite, Public, and Private channels on the left-hand sidebar.
+  * Make sure that you scroll all the way to the top in the channel list on the left-hand sidebar for the screenshot.
+  * You can have a few unreads or mentions visible, but don't include an “unread posts” indicator in the left-hand sidebar.
 * **Favorites channel list**: Include the following:
-  * One Public channel
-  * One Direct Message channel with someone who is online
-  * One Group Direct Message channel using people with short names to avoid truncation
+  * One Public channel.
+  * One Direct Message channel with someone who is online.
+  * One Group Direct Message channel using people with short names to avoid truncation.
 * **Center pane:**
-  * Make the center pane one of the Favorited channels
-  * Make sure that the heading of the center pane is fully visible to avoid truncation
-  * Make the first message in the center pane fully visible right below the channel header
+  * Make the center pane one of the Favorited channels.
+  * Make sure that the heading of the center pane is fully visible to avoid truncation.
+  * Make the first message in the center pane fully visible right below the channel header.
 * **Team list**
-  * Connect team names to channel names, e.g. Contributors, Developers, Toolkit, etc. to contribute to a broader overall theme and story
-  * E.g. could use icons of different maps, or city skylines, to indicate offices of different teams, or business units of a bank (customer service, security, research, etc.), etc
+  * Connect team names to channel names, e.g. Contributors, Developers, Toolkit, etc. to contribute to a broader overall theme and story.
+  * E.g. could use icons of different maps, or city skylines, to indicate offices of different teams, or business units of a bank (customer service, security, research, etc.), etc.
 * **Clarity:** 
-  * Avoid showing any text with acronyms and abbreviations
-  * Do not show any bugs or defects
+  * Avoid showing any text with acronyms and abbreviations.
+  * Do not show any bugs or defects.
 * **Outline:**
-  * Ensure that the screenshot has a grey \(\#F7F9FA\) outline in all four edges. This helps ensure the screenshot looks good against both dark and light backgrounds
-* **Outstanding look:** Ensure that the contents of the screenshot shows the Mattermost product in the best light
+  * Ensure that the screenshot has a grey \(\#F7F9FA\) outline in all four edges. This helps ensure the screenshot looks good against both dark and light backgrounds.
+* **Outstanding look:** Ensure that the contents of the screenshot shows the Mattermost product in the best light.
 
-  > * Show the feature in action
-  > * Make sure that the screenshot is positive - give whoever is viewing it a positive emotion
-  > * Show how the feature can be extended and customized. For instance, use custom slash commands instead of the default commands
+  > * Show the feature in action.
+  > * Make sure that the screenshot is positive - give whoever is viewing it a positive emotion.
+  > * Show how the feature can be extended and customized. For instance, use custom slash commands instead of the default commands.
 
-### Sharing a Screenshot
+### Sharing a screenshot
 
-1. **Share the original** - Always share the original in .JPG or .PNG format, or pasted in a slide 
-   1. If you share screenshots in a slide with a drop shadow or other formatting, make sure the original is provided as a backup in case the user needs a different manipulation 
-2. **Share the manipulation \(optional\)** - If you're modifying screenshots using a format that can include layer or the original manipulation \(e.g. Photoshop\), offer the file containing modifications if you can in .PSD or .TIF format
+1. **Share the original:** Always share the original in .JPG or .PNG format, or pasted in a slide.
+   1. If you share screenshots in a slide with a drop shadow or other formatting, make sure the original is provided as a backup in case the user needs a different manipulation.
+2. **Share the manipulation \(optional\):** If you're modifying screenshots using a format that can include layer or the original manipulation \(e.g. Photoshop\), offer the file containing modifications if you can in .PSD or .TIF format.
 
 ### Recording a GIF
 
@@ -80,7 +80,7 @@ Example of what not to do:
 
 #### Do show sub-components framed in grey \(\#F7F9FA\) background
 
-Instead, show the sub-component at 100% zoom with a 12pt white border \(so there is white space\) and a grew \(\#F7F9FA\) background with no border, so the image is cleanly framed:
+Instead, show the sub-component at 100% zoom with a 12pt white border \(so there's white space\) and a grey \(\#F7F9FA\) background with no border, so the image is neatly framed:
 
 ![](../../../.gitbook/assets/screenshot_guidelines2.png)
 


### PR DESCRIPTION
Adjusted capitalization and removed white spaces. One typo fix, and "left-hand side" > "left-hand sidebar".

@jasonblais: I'm considering including some instructions around the type of names and references we should NOT use going forward, with the link you shared. Would that be appropriate here?