### PR TITLE
Update paid-time-off

### DIFF
--- a/operations/workplace/people/working-at-mattermost/paid-time-off.md
+++ b/operations/workplace/people/working-at-mattermost/paid-time-off.md
@@ -57,6 +57,7 @@ We have entities in Germany, UK, US, and we have a large Canadian contingent, so
 * Ascension Day (Germany) \(5/13/2021\)
 * Spring Bank Holiday (UK) \(5/31/2021\)
 * Memorial Day (US) \(5/31/2021\)
+* Juneteenth (US) \(6/18/2021\)
 * Whit Monday (Germany) \(6/24/2021\)
 * Canada Day (Canada) \(7/1/2021\)
 * Independence Day (US) \(7/5/2021\)


### PR DESCRIPTION
Add new US federal holiday, Juneteenth. June 19th but observed on the 18th in 2021.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
