### PR TITLE
Update README.md

### DIFF
--- a/operations/research-and-development/README.md
+++ b/operations/research-and-development/README.md
@@ -59,7 +59,7 @@ We have three verticals: Messaging, Incident Collaboration, and Focalboard. The 
 
 #### Technical Writer
 
-* Carrie Warner - Senior Technical Writer
+* Carrie Warner - Technical Writer
 
 #### Full Stack 1 (name TBD)
 
@@ -110,7 +110,6 @@ We have three verticals: Messaging, Incident Collaboration, and Focalboard. The 
 * Alejandro García Montoro - Engineer
 * Caleb Roseland - Engineer
 * Shota Gvinepadze - Engineer
-* Prapti Shrestha - QA SDET
 * Ian Tao - Product Manager
 * Abhijit Singh - UX Designer
 * Justine Geffen - Technical Writer
@@ -124,7 +123,8 @@ We have three verticals: Messaging, Incident Collaboration, and Focalboard. The 
 * Hossein Ahmadian - Engineer
 * Harshil Sharma - Engineer
 * Ogi Marusic - QA
-* Chen-I Lim - Product Manager
+* Chen Lim - Product Manager
+* Asaad Mahmood - UX Designer
 * Michael Gamble - UX Designer
 * Justine Geffen - Technical Writer
 
@@ -141,7 +141,6 @@ We have three verticals: Messaging, Incident Collaboration, and Focalboard. The 
 * Pablo Vélez Vidal - Engineer
 * Nick Misasi - Engineer
 * Steve Mudie - QA
-* Najla Dadmand - Product Manager
 * Anneliese Klein - UX Designer
 * Justine Geffen - Technical Writer
 * Eric Nelson - Analytics


### PR DESCRIPTION
Removed two offboarded team members.
 
As an aside, I started updating roles and appending the full title (e.g., "Senior Product Manager" instead of just "Product Manager"). I realized, though, that this would have a knock-on effect for all roles and I think it may be more equalizing to have the Senior Managers and Leads identified and everyone else listed on the same "level". 

That said, I'm open to updating this with all the correct role names if that's appropriate. Thoughts, @wiersgallak and @jasonblais?