### PR TITLE
Creating an Event Code of Conduct

### DIFF
--- a/operations/messaging-and-math/event-code-of-conduct.md
+++ b/operations/messaging-and-math/event-code-of-conduct.md
@@ -1,16 +1,23 @@
+# Event Code of Conduct
+
 Mattermost is dedicated to Equity, Diversity, and Inclusion.
 
-Mattermost events are professional conferences focused on various aspects of Open Source, our technology stack, and other parts of our community. Teams involved in these events strive to provide a respectful, safe and inclusive environment for all participants, regardless of gender identity, sexual orientation, disability, appearance, ethnicity, race, national origin, age, religion, or any other protected categories under applicable law. All participants, including speakers, attendees, and staff are expected to behave with integrity and respect towards other participants attending or anyone involved with the online conference.
+Mattermost events are professional conferences focused on various aspects of Open Source, our technology stack, and other parts of our community. 
 
-Mattermost is committed to informing all participants about this code of conduct. This Code of Conduct supplements, but does not affect, the application of other relevant policies, regulations, rules and laws, including laws regulating the premises in which the online or in-person event takes place, and any applicable host country agreement. Mattermost complies with such policies, and will report all inappropriate conduct accordingly. If participants are provided with personalized credentials allowing them access to the online conference, these credentials are personal and non-transferable. Non-registered individuals will not be able to access the online conference, unless upon prior agreement with the event organizers. Mattermost expects that participants in online conferences will interact with fellow attendees in the same way as at a physical conference.
+Teams involved in these events strive to provide a respectful, safe and inclusive environment for all participants, regardless of gender identity, sexual orientation, disability, appearance, ethnicity, race, national origin, age, religion, or any other protected categories under applicable law. All participants, including speakers, attendees, and staff are expected to behave with integrity and respect towards other participants attending or anyone involved with the online conference.
 
-All communication, be it verbal or electronic, must be carried out in a respectful and polite manner. Inappropriate messaging or contact will not be tolerated. For the purpose of these guidelines, harassment consists of improper or unwelcome conduct that might reasonably be perceived as causing offense or humiliation to another person. Harassment may involve any conduct of a verbal, non-verbal or physical nature, including written and electronic communication, and may occur between persons of the same or different genders. Harassment in any form is not tolerated. Event venues or employers of reported individuals may be notified about filed harassment reports.
+Mattermost is committed to informing all participants about this Code of Conduct. This Code of Conduct supplements, but does not affect, the application of other relevant policies, regulations, rules and laws, including laws regulating the premises in which the online or in-person event takes place, and any applicable host country agreement. Mattermost complies with such policies, and will report all inappropriate conduct accordingly. If participants are provided with personalized credentials allowing them access to the online conference, these credentials are personal and non-transferable. Non-registered individuals will not be able to access the online conference, unless upon prior agreement with the event organizers. Mattermost expects that participants in online conferences will interact with fellow attendees in the same way as at a physical conference.
+
+All communication, be it verbal or electronic, must be carried out in a respectful and polite manner. Inappropriate messaging or contact will not be tolerated. 
+
+For the purpose of these guidelines, harassment consists of improper or unwelcome conduct that might reasonably be perceived as causing offense or humiliation to another person. Harassment may involve any conduct of a verbal, non-verbal or physical nature, including written and electronic communication, and may occur between persons of the same or different genders. Harassment in any form is not tolerated. Event venues or employers of reported individuals may be notified about filed harassment reports.
+
 Examples of harassment include, but are not limited to:
 
 * Verbal comments that reinforce social structures of domination related to gender, gender identity, sexual orientation, disability, physical appearance, body size, ethnicity, race, age, religion, political affiliation.
 * The production or non-consensual sharing of harassing non-consensual photography or unwanted recording, including sexual images in public spaces. (in any format, electronic or otherwise).
-* Deliberate intimidation, stalking or following.
-* Sustained disruption of talks, sessions or other events.
+* Deliberate intimidation, stalking, or following.
+* Sustained disruption of talks, sessions, or other events.
 * Inappropriate contact, including via electronic communications.
 * Unwelcome sexual attention.
 * Advocating for, or encouraging, any of the above behaviors.

--- a/operations/messaging-and-math/event-code-of-conduct.md
+++ b/operations/messaging-and-math/event-code-of-conduct.md
@@ -1,0 +1,18 @@
+Mattermost is dedicated to Equity, Diversity, and Inclusion.
+
+Mattermost events are professional conferences focused on various aspects of Open Source, our technology stack, and other parts of our community. Teams involved in these events strive to provide a respectful, safe and inclusive environment for all participants, regardless of gender identity, sexual orientation, disability, appearance, ethnicity, race, national origin, age, religion, or any other protected categories under applicable law. All participants, including speakers, attendees, and staff are expected to behave with integrity and respect towards other participants attending or anyone involved with the online conference.
+
+Mattermost is committed to informing all participants about this code of conduct. This Code of Conduct supplements, but does not affect, the application of other relevant policies, regulations, rules and laws, including laws regulating the premises in which the online or in-person event takes place, and any applicable host country agreement. Mattermost complies with such policies, and will report all inappropriate conduct accordingly. If participants are provided with personalized credentials allowing them access to the online conference, these credentials are personal and non-transferable. Non-registered individuals will not be able to access the online conference, unless upon prior agreement with the event organizers. Mattermost expects that participants in online conferences will interact with fellow attendees in the same way as at a physical conference.
+
+All communication, be it verbal or electronic, must be carried out in a respectful and polite manner. Inappropriate messaging or contact will not be tolerated. For the purpose of these guidelines, harassment consists of improper or unwelcome conduct that might reasonably be perceived as causing offense or humiliation to another person. Harassment may involve any conduct of a verbal, non-verbal or physical nature, including written and electronic communication, and may occur between persons of the same or different genders. Harassment in any form is not tolerated. Event venues or employers of reported individuals may be notified about filed harassment reports.
+Examples of harassment include, but are not limited to:
+
+* Verbal comments that reinforce social structures of domination related to gender, gender identity, sexual orientation, disability, physical appearance, body size, ethnicity, race, age, religion, political affiliation.
+* The production or non-consensual sharing of harassing non-consensual photography or unwanted recording, including sexual images in public spaces. (in any format, electronic or otherwise).
+* Deliberate intimidation, stalking or following.
+* Sustained disruption of talks, sessions or other events.
+* Inappropriate contact, including via electronic communications.
+* Unwelcome sexual attention.
+* Advocating for, or encouraging, any of the above behaviors.
+
+The Mattermost team reserves the right to take any action as deemed necessary as a consequence of any breach of this Code of Conduct. This includes reporting to event venues or employers and the permanent removal from any of our online conferences. In case of a breach of the Code of Conduct, the concerned individuals are requested to contact the event organizers at [community@mattermost.com](mailto:community@mattermost.com).


### PR DESCRIPTION
This is the addition of the event Code of Conduct to ensure any events we run or are a part of are governed by a set of standards to ensure we are creating a safe, inclusive environments. Attendees of events we organize and Mattermost employees, contributors, and contractors will be held to this standard. This will also be applied to Mattermost employees, contributors, and contractors at any external events.

