### PR TITLE
First draft of new SET docs

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -94,6 +94,8 @@
     * [Integrations Team Processes](operations/research-and-development/engineering/integrations.md)
     * [Plugin Release Process](operations/research-and-development/engineering/plugin-release-process.md)
     * [Data Engineering](operations/research-and-development/engineering/data-engineering.md)
+    * [Sustained Engineering](operations/research-and-development/engineering/sustained-engineering/team.md)
+       * [On Call](operations/research-and-development/engineering/sustained-engineering/on-call.md)
   * [Quality Assurance](operations/research-and-development/quality/README.md)
     * [QA Workflow](operations/research-and-development/quality/qa-workflow/README.md)
     * [QA Testing Tips and Tools](operations/research-and-development/quality/testing-tips-and-tools.md)

--- a/operations/research-and-development/engineering/sustained-engineering/on-call.md
+++ b/operations/research-and-development/engineering/sustained-engineering/on-call.md
@@ -1,0 +1,74 @@
+# On Call
+
+## Onboarding
+
+### Find Out When You’re On-Call
+To find out when you’re on call follow the below checklist:
+
+1. Add the SET calendar to your Google Calendar
+    1. Log in to OpsGenie via OneLogin
+    2. Open each of the following schedules that are relevant to you:
+        * [Sustained Engineering_schedule](https://mattermost.app.opsgenie.com/settings/schedule/detail/cc2b2e08-b690-434b-a8a0-b4943f8eb3d2)
+        * [Backup Sustained Engineering_Schedule](https://mattermost.app.opsgenie.com/settings/schedule/detail/967e7812-e594-4d0f-8f26-8b2e98f43906)
+        * [Lead Sustained Engineering_schedule](https://mattermost.app.opsgenie.com/settings/schedule/detail/a121cd12-2961-47bb-8fb0-7d7252a18fb6)
+    3. For each click the litte "Open Calendar" calendar button that appears when you hover over the calendar. This will open a `webcal://` link, copy this link
+	1. In Google calendar (or your prefered calendaring app) Go to “Add Calendar”, select “From URL” and paste the `webcal` URL. After it's added, rename it to something appropriate.
+2. Find yourself on the calendar
+	1. At the top right of Google Calendar click the search icon
+	2. Type in the below based on your rotation for SET: “\<your-name\> Engineering\_schedule”
+	3. The results should show you the dates you’re on call
+
+### Before Your First Day On-Call
+There’s a few things you should set up before your first day on call. Work through the following checklist a couple days before you start on-call:
+
+1. Log in to OpsGenie
+	1. Go to [https://mattermost.onelogin.com/portal](https://mattermost.onelogin.com/portal) and log in
+	2. Search for and click the OpsGenie icon
+2. Install the OpsGenie app on your phone
+	1. Search “OpsGenie” in the Apple App Store or Google Play Store
+	2. Open the app and type in your email, **making sure to select US as the data center region**
+	3. For organization, enter “mattermost”
+	4. This should redirect you to OneLogin to complete the log in
+3. Configure your OpsGenie notification rules in your desktop browser
+	1. Go to [https://mattermost.app.opsgenie.com/settings/user/notification](https://mattermost.app.opsgenie.com/settings/user/notification)
+	2. Under “Contact methods” add your phone number for SMS and/or Voice
+	3. Under “Notification rules” you should configure the rules for:
+		1. New Alert
+		2. Schedule Start
+		3. Schedule End
+	4. How you want to configure your notifications is up to you but **make sure it’s configured in a way that will get your attention**
+		1. An example configuration is:
+			1. Notify mobile immediately
+			2. Notify via SMS after 5 minutes
+			3. Notify via phone call after 10 minutes
+	5. Test your notification rules by creating a test alert
+		1. Go to [https://mattermost.app.opsgenie.com/alert/list](https://mattermost.app.opsgenie.com/alert/list)
+		2. Click “Create alert” in the top right
+		3. Name the alert “Test Alert”
+		4. Add yourself under “Responders”
+		5. Click “Create”
+		6. Confirm that your notification rules are followed
+		7. Acknowledge the alert
+		8. Close the alert
+4. Join [~Incidents Status](https://community-daily.mattermost.com/private-core/channels/incidents) channels on community.mattermost.com
+5. Read [Incident Response](https://docs.google.com/document/d/1-AWQJQelgKvGVSP6sOIi9EOSVjxXVlJlwNuJlkcXKGA/edit#heading=h.uk4q4qkm81h0) to familiarize yourself with the response process
+6. Create a test incident to familiarize yourself with the Incident Response plugin
+	1. On community.mattermost.com, click the “!” icon in the channel header
+	2. Click the “+” to start a new incident
+	3. Choose playbook
+		1. For SET, use “Sustained Engineering”
+		2. For Cloud, use “Cloud Incident Response Playbook”
+	4. End the incident
+
+### Your First Day On-Call
+On your first day on call, do the following:
+
+1. Check if you’re on-call as primary or back up
+	1. Log in to OpsGenie
+	2. Go to [https://mattermost.app.opsgenie.com/schedule/whoIsOnCall](https://mattermost.app.opsgenie.com/schedule/whoIsOnCall) and click on the schedule for the rotation you’re on
+	3. You’re on-call as primary if you’re listed under one of the rotations that has “Primary” in the name
+2. Start your shift
+	1. OpsGenie will notify you when your shift starts or [check the schedule](https://mattermost.app.opsgenie.com/schedule/whoIsOnCall)
+3. Watch for alerts from OpsGenie and follow [Incident Response](https://docs.google.com/document/d/1-AWQJQelgKvGVSP6sOIi9EOSVjxXVlJlwNuJlkcXKGA/edit#heading=h.uk4q4qkm81h0) to respond to any alerts
+4. End your shift
+	1. OpsGenie will notify you when your shift ends or [check the schedule](https://mattermost.app.opsgenie.com/schedule/whoIsOnCall)

--- a/operations/research-and-development/engineering/sustained-engineering/team.md
+++ b/operations/research-and-development/engineering/sustained-engineering/team.md
@@ -1,0 +1,68 @@
+# The Sustained Engineering Team (SET)
+The Sustained Engineering Team (SET) is responsible for improving and maintaining quality of the Mattermost products. Its role is ever evolving, but currently primarily focuses on:
+
+1. Responding to customer incidents and questions escalated by support (either via OpsGenie or the [~Sustained Engineering](https://community.mattermost.com/core/channels/sustained-engineering) channel)
+2. Responding to any incidents on company Mattermost environments like community and community-daily
+
+Often, people in SET primarily play the role first responders, then handing off to whichever engineering team best equipped to resolve the issue. 
+
+## Team Members
+SET is a rotating team that is comprised of engineers from the different engineering teams. The rotation is on a weekly cycle for engineers, and two-week cycle for leads. Who is currently on SET can be seen in the header of the [~Sustained Engineering](https://community.mattermost.com/core/channels/sustained-engineering) channel.
+
+Engineering teams will commit a total of 4 engineers plus a lead to SET for each rotation. While on SET, that engineer should attend their feature team's sprint planning, but it should be taken into account that any urgent SET-related issue may take them out of the regular day-to-day planned work. Plan appropriately.
+
+## Roles
+The **SET Lead** is usually one of the engineering team's Engineering Leads. The SET lead, leads the SET team during its rotation. In practice this means the SET lead:
+
+1. Ensures that raised issues are being addressed
+2. Communicates the status of ongoing issues appropriately to stake holders
+3. Is a point of escalation in case stake holders do not else who else to escalate to
+
+The SET Lead is also on call (via OpsGenie), and is escalated to whenever neither the SET primary nor SET backup acknowledge an issue in the appropriate time. 
+
+The **SET Primary** is usually an engineer from one of the engineering teams. The SET Primary is the first person to respond to any issues escalated. There are two ways to respond to an issue:
+
+1. Handle the issue themselves, e.g. by implementing a fix
+2. Hand off the issue to the appropriate team or person
+
+The **SET Backup** is usually an engineer from one of the engineering teams. In case thet SET Primary is not available or unresponsive, the back-up temporarily takes over. 
+
+
+## Workflow Process
+
+SET works in a continuous style using this [Kanban JIRA board](https://mattermost.atlassian.net/secure/RapidBoard.jspa?rapidView=33). Tickets in the TO DO column should be organized from highest priority to lowest priority, based on the [Priority of Work](#priority-of-work) section. The SET lead should make sure that the tickets are priority ordered but team members can move tickets around to meet the correct priorities as necessary.
+
+Team members on SET should pull tickets off the top of TO DO queue, work on them to completion and then pull another one off the TO DO queue.
+
+Discussion related to SET should occur in the [~Sustained Engineering](https://community.mattermost.com/core/channels/sustained-engineering) channel on https://community.mattermost.com.
+
+
+## Triage
+
+SET triages SET tickets asynchronously and also helps Release Manager to
+
+* Help route new unassigned tickets to the appropriate engineering team
+* Assign bugs to SET when there is no clear engineering team owner
+* Make sure reported bugs are in fact bugs and recommend turning non-bugs into stories or feature requests
+
+## Priority of Work
+
+Below is how SET prioritizes what is worked on.
+
+1. Quality issues affecting community.mattermost.com or community-daily.mattermost.com
+  * When a high impact issue affects the community server, SET responds and is responsible to coordinate fixing
+  * Primary goal is to restore stability, whether this is fixing or reverting code
+2. Handles customer support escalation
+  * Primary goal is to help with issues that require code change
+  * Be helpful with training/knowledge sharing for the support team
+  * Identify customer support requests that are features and route to PM as necessary
+3. General bug fixes
+  * Pick up any bugs in triage without an obvious owning feature team
+  * Work on bugs in this order: hotfix, release, customer reported, other
+
+## Customer and Pre-Sales Support Escalation Process
+
+Part of SET's responsibility is to interface with the customer support team. SET's primary goal in respect to support is to triage escalated support issues, work on any high priority customer bugs requiring code change, as well as provide training and knowledge share with the customer support team. 
+
+For details on the Customer/Pre-Sales Support Escalation Process, please refer to [this document](https://docs.google.com/document/d/1eEnG0YA6G8_1futRlvBs2Vm88xkc0nTnZCynYXZNTBE/edit?usp=sharing). 
+


### PR DESCRIPTION
#### Summary

The goal is to move and update the old SET (Sustained Engineering) content from [here](https://developers.mattermost.com/internal/sustained-engineering/) and some internal google docs to the handbook.

This is a first pass, but already more up-to-date than what we had on the developers.mattermost.com site.