### PR TITLE
Add organization secton to R&D for describing overall structure layout

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -104,6 +104,8 @@
   * [Quality Assurance](operations/research-and-development/quality/README.md)
     * [QA Workflow](operations/research-and-development/quality/qa-workflow.md)
     * [QA Testing Tips and Tools](operations/research-and-development/quality/testing-tips-and-tools.md)
+  * [Organization](operations/research-and-development/organization/README.md)
+    * [Channels](operations/research-and-development/organization/channels.md)
 * [Messaging and Math](operations/messaging-and-math/README.md)
   * [How to guides for M&M](operations/messaging-and-math/how-to-guides-for-m-and-m/README.md)
     * [How to create release announcements](operations/messaging-and-math/how-to-guides-for-m-and-m/how-to-create-release-announcements.md)

--- a/operations/research-and-development/organization/README.md
+++ b/operations/research-and-development/organization/README.md
@@ -2,7 +2,7 @@
 
 The source of truth for the R&D org structure and team membership is [this spreadsheet](https://docs.google.com/spreadsheets/d/1lH8QIjQGEoGospDUdVs_LQ_i2b82I1ce6W7z18vhPTQ/edit#gid=1820415931).
 
-R&D is split into five different divisions: Products, Cloud, Platform, Security and Community.
+R&D is split into five different divisions: Products, Cloud, Platform, Security, and Community.
 
 ## Products
 

--- a/operations/research-and-development/organization/README.md
+++ b/operations/research-and-development/organization/README.md
@@ -1,0 +1,29 @@
+# R&D Organization
+
+The source of truth for the R&D org structure and team membership is [this spreadsheet](https://docs.google.com/spreadsheets/d/1lH8QIjQGEoGospDUdVs_LQ_i2b82I1ce6W7z18vhPTQ/edit#gid=1820415931).
+
+R&D is split into five different divisions: Products, Cloud, Platform, Security and Community.
+
+## Products
+
+The Products division is split into a number of different verticals, each responsible for a single product. Currently there are three but more will be created as new products are added. The current product vertcals are:
+
+* [Channels](/operations/research-and-development/organization/channels)
+* Boards
+* Playbooks
+
+## Cloud
+
+The Cloud division is responsible for delivery of the Mattermost products as a SaaS product, in addition to growth and build system related areas.
+
+## Platform
+
+The Platform division is responsible for the platforms that support and span the product verticals.
+
+## Security
+
+The Security division is responsible for both Product and Infrastructure security.
+
+## Community
+
+The Community division is responsible for developer and user community relations.

--- a/operations/research-and-development/organization/README.md
+++ b/operations/research-and-development/organization/README.md
@@ -6,7 +6,7 @@ R&D is split into five different divisions: Products, Cloud, Platform, Security,
 
 ## Products
 
-The Products division is split into a number of different verticals, each responsible for a single product. Currently there are three but more will be created as new products are added. The current product vertcals are:
+The Products division is split into a number of different verticals, each responsible for a single product. The current product verticals are:
 
 * [Channels](/operations/research-and-development/organization/channels)
 * Boards

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -1,0 +1,64 @@
+# Channels
+
+Channels is split into feature teams and platform teams.
+
+## Feature Teams
+
+The feature teams are responsible for designing, developing and maintaining the features of the Channels product. They are full stack and own feature development across the entire tech stack (web app, mobile, desktop and backend).
+
+These teams are flexible enough to work on whatever is highest impact. Each team does have areas of expertise and features they own but any feature team can work on any portion of the product.
+
+The teams are:
+
+### Ursa (feature team #1)
+
+Areas of expertise:
+
+* Groups
+* LDAP
+* Permissions
+* System Console
+* Compliance
+* Data Retention
+* Mobile sidebar/categories
+
+### Interstellar (feature team #2)
+
+Areas of expertise:
+
+* Apps
+* Webhooks
+* Slash Commands
+* Plugins
+
+### Apollo (feature team #3)
+
+Areas of expertise:
+
+* Posts
+* Threads
+* File Previews
+
+## Platform Teams
+
+The platform teams are responsible for building and maintaining the systems that the feature teams rely on.
+
+**Why are these teams in the Channels product vertical and not the Platform division?**
+
+Until recently Channels was the only product Mattermost had and was itself the platform. As a result of this a lot of the platform is tightly coupled to the Channels product. The server and web app parts of the platform are especially tightly coupled. The goal is to eventually move these teams, or some version of them, out of the Channels product vertical when that coupling is looser.
+
+The teams are:
+
+### Web Platform
+
+The role of the Web Platform team is to own the infrastructure behind the Web App and Desktop App while supporting other teams that are using that infrastructure.
+
+Within the web app, that means tooling (eg. build tools, testing frameworks, style checking), core systems (eg. Redux, routing), and helping maintain the core features of the app. For the areas owned, the team is also be responsible for educating other teams about those areas and helping them coordinate work that might require changes to those things.
+
+The team is also responsible for dictating the coding style and practices used throughout the web app which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the web app whenever possible.
+
+The team can't, however, be responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Feature teams are able to move much quicker because they're often writing brand new code which gives them more opportunities to try out new technologies and practices. When those experiments are successful though, we'll be open to help integrate them back into the Web App and make them available for other Mattermost projects.
+
+### Server Platform
+
+The role of the Server Platform team is to own the backend multi-product architecture and server performance while supporting other teams that rely on the server.

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -4,7 +4,7 @@ Channels is split into feature teams and platform teams.
 
 ## Feature Teams
 
-The feature teams are responsible for designing, developing and maintaining the features of the Channels product. They are full stack and own feature development across the entire tech stack (web app, mobile, desktop and backend).
+The feature teams are responsible for designing, developing, and maintaining the features of the Channels product. They are full stack and own feature development across the entire tech stack (Web App, Mobile, Desktop, and backend).
 
 These teams are flexible enough to work on whatever is highest impact. Each team does have areas of expertise and features they own but any feature team can work on any portion of the product.
 

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -57,7 +57,7 @@ Within the web app, that means tooling (eg. build tools, testing frameworks, sty
 
 The team is also responsible for dictating the coding style and practices used throughout the web app which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the web app whenever possible.
 
-The team can't, however, be responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Feature teams are able to move much quicker because they're often writing brand new code which gives them more opportunities to try out new technologies and practices. When those experiments are successful though, we'll be open to help integrate them back into the Web App and make them available for other Mattermost projects.
+The team is not responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Because feature teams are able to move much quicker when they're writing brand new code, they have more opportunities to try out new technologies and practices. When those experiments are successful, the Web platform team will help integrate them back into the Web App and make them available for other Mattermost projects.
 
 ### Server Platform
 

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -57,7 +57,7 @@ Within the Web App, that means tooling (e.g. build tools, testing frameworks, st
 
 The team is also responsible for dictating the coding style and practices used throughout the Web App which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the Web App whenever possible.
 
-The team is not responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Because feature teams are able to move much quicker when they're writing brand new code, they have more opportunities to try out new technologies and practices. When those experiments are successful, the Web platform team will help integrate them back into the Web App and make them available for other Mattermost projects.
+The team is not responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Because feature teams are able to move much quicker when they're writing brand new code, they have more opportunities to try out new technologies and practices. When those experiments are successful, the Web Platform team will help integrate them back into the Web App and make them available for other Mattermost projects.
 
 ### Server Platform
 

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -59,6 +59,22 @@ The team is also responsible for dictating the coding style and practices used t
 
 The team is not responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Because feature teams are able to move much quicker when they're writing brand new code, they have more opportunities to try out new technologies and practices. When those experiments are successful, the Web Platform team will help integrate them back into the Web App and make them available for other Mattermost projects.
 
+Areas of expertise:
+
+* Web App performance
+* Redux store structure
+* Desktop
+* Routing
+* Frontend coding style and best practices
+
 ### Server Platform
 
 The role of the Server Platform team is to own the backend multi-product architecture and server performance while supporting other teams that rely on the server.
+
+Areas of expertise:
+
+* Multi-product and server platform archiecture
+* Load testing and server performance
+* Database requirements
+* Clustering and high availability
+* Backend coding style and best practices

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -53,7 +53,7 @@ The teams are:
 
 The role of the Web Platform team is to own the infrastructure behind the Web App and Desktop App while supporting other teams that are using that infrastructure.
 
-Within the web app, that means tooling (eg. build tools, testing frameworks, style checking), core systems (eg. Redux, routing), and helping maintain the core features of the app. For the areas owned, the team is also be responsible for educating other teams about those areas and helping them coordinate work that might require changes to those things.
+Within the Web App, that means tooling (e.g. build tools, testing frameworks, style checking), core systems (e.g. Redux, routing), and helping maintain the core features of the app. For the areas owned, the team is also responsible for educating other teams about those areas and helping them coordinate work that might require changes to those things.
 
 The team is also responsible for dictating the coding style and practices used throughout the web app which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the web app whenever possible.
 

--- a/operations/research-and-development/organization/channels.md
+++ b/operations/research-and-development/organization/channels.md
@@ -55,7 +55,7 @@ The role of the Web Platform team is to own the infrastructure behind the Web Ap
 
 Within the Web App, that means tooling (e.g. build tools, testing frameworks, style checking), core systems (e.g. Redux, routing), and helping maintain the core features of the app. For the areas owned, the team is also responsible for educating other teams about those areas and helping them coordinate work that might require changes to those things.
 
-The team is also responsible for dictating the coding style and practices used throughout the web app which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the web app whenever possible.
+The team is also responsible for dictating the coding style and practices used throughout the Web App which can be used as a reference for other JS projects. As recommended practices change, the team will work with the community and other teams to implement those in the Web App whenever possible.
 
 The team is not responsible for experimenting with new technologies or dictating the project structure/tooling used for all other JS projects within Mattermost. Because feature teams are able to move much quicker when they're writing brand new code, they have more opportunities to try out new technologies and practices. When those experiments are successful, the Web platform team will help integrate them back into the Web App and make them available for other Mattermost projects.
 


### PR DESCRIPTION
<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
A lot of the context and information for why & how R&D is organized is tribal. This an attempt to codify some of it into the handbook.
