### PR TITLE
Update DevOps channel link to an active channel

### DIFF
--- a/company/how-to-guides-for-staff/how-to-update-handbook.md
+++ b/company/how-to-guides-for-staff/how-to-update-handbook.md
@@ -27,7 +27,7 @@ The Handbook is a public-facing body of work and although it's a constantly-evol
 
 If this is your first time contributing to Mattermost, first read the [Mattermost Contributor Agreement](https://www.mattermost.org/mattermost-contributor-agreement/) and sign it \(at the bottom of the page\), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true). Please ensure the **GitHub username** field matches your GitHub username exactly, including capitalization.
 
-Then, please request access to the Mattermost organization [DevOps Team Channel](https://community.mattermost.com/private-core/channels/devops-team). This means that you can edit the files in the Handbook repo and not have to create a fork for your changes.
+Then, please request access to the Mattermost organization [DevOps Team Channel](https://community.mattermost.com/core/channels/build). This means that you can edit the files in the Handbook repo and not have to create a fork for your changes.
 
 Now you're ready to get started.
 


### PR DESCRIPTION
Changing the devops channel link to an active channel. I'm not 100% certain its the right channel so feedback there is very welcome. 