### PR TITLE
Moving G Doc into handbook for "Decision Making" 

### DIFF
--- a/operations/operations/company-processes/issue-solution.md
+++ b/operations/operations/company-processes/issue-solution.md
@@ -1,14 +1,12 @@
 # Issue/Solution Process
 
-Issue/Solution Proposal is a tool for increasing clarity, speed, and output in teams.
-
-Over time, we will be integrating ISP functionality in [Focalboard](https://focalboard.com), and unti then we will use other systems.
+Issue/Solution Proposal is a tool for increasing clarity, speed, and output in teams. Over time, we will be integrating ISP functionality in [Focalboard](https://focalboard.com), and unti then we will use other systems.
 
 Note: Special thanks to [Matt Mochary](https://www.linkedin.com/in/matt-mochary-34bb4/) for the framework on which this system is based.
 
-# Decision Making
+# Decision making
 
-## Getting Buy-In 
+## Getting buy-in 
 
 One of the core challenges in leadership is getting teams to buy into a decision intellectually and emotionally.
 
@@ -16,18 +14,18 @@ You create buy-in when you make people feel they are part of the decision, and t
 
 Broadly, there are three ways to make a decision. Each has a different time requirement, and creates a different level of buy-in. The methods that create the most buy-in also take the most amount of time: 
   
-### Method A: Unilateral Decision 
+### Method A: Unilateral decision 
 
-For a decision where there's a clear decision maker based on Areas of Responsibility (see Type 1 vs Type 2 below), the decision maker announces a decision to the team, and answers questions. This is typical when a decision is within someone’s Area of Responsibility. 
+For a decision where there's a clear decision maker based on Areas of Responsibility (see Type 1 vs Type 2 below), the decision maker announces a decision to the team, and answers questions. This is typical when a decision is within someone’s Area of Responsibility.
 
-Example: A digital marketer who's is responsibile for managing the executing of advertising campaigns using different vendors would make a Method A decision on which vendors to choose, and let others know. 
+Example: A digital marketer who's responsible for managing the executing of advertising campaigns using different vendors would make a Method A decision on which vendors to choose, and let others know.
 
 Pros: 	
 - Takes very little time.
 Con:    	
 - Creates very little buy-in and gets no benefit from the team’s knowledge and experience. 
 
-### Method B: Issue and Proposed Solution 
+### Method B: Issue and proposed solution 
 
 A Decision-Maker creates (or assigns someone to create) a written straw man (a hypothetical answer designed to inspire discussion), shares it with the team, invites team to give feedback (written and verbal), facilitates group discussion, makes everyone feel heard by repeating back their comments, and then makes a final decision.
 
@@ -36,9 +34,9 @@ Pros:
 Con:   	
 - Takes more time.
 
-### Method C: Wallow on Strategic Issue 
+### Method C: Wallow on strategic issue 
 
-Decision-Maker invites a team to a meeting where a dilemma is discussed from scratch with no straw man. Team shares ideas. Decision-maker repeats back everyone’s ideas until they feel heard.  Decision-Maker shares her own idea last (because hers is the loudest voice in the room). Decision-maker makes decision.  (Note that this is not a consensus decision.  Buy-in is created by Decision-Maker confirming that she heard all ideas, not by accommodating all ideas.)
+Decision-Maker invites a team to a meeting where a dilemma is discussed from scratch with no straw man. Team shares ideas. Decision-maker repeats back everyone’s ideas until they feel heard. Decision-Maker shares their own idea last (because theirs is the loudest voice in the room). Decision-maker makes decision.  (Note that this is not a consensus decision. Buy-in is created by Decision-Maker confirming that they heard all ideas, not by accommodating all ideas.)
 
 Pros: 	
 - Creates the most buy-in. Gets a lot of benefit from the collective wisdom of the team.
@@ -51,48 +49,45 @@ So, which method should you use? It depends on how significant the decision is, 
 
 For everyday, low-impact issues (for example, entering a new reseller relationship), Method A is sufficient. For major, core issues (for example, Company 10-Year Vision), Method C is necessary. For everything in between (the vast majority of important decisions), Method B is optimal.
 
-For Method B, we use the Issue/Proposed Solution method: 
+For Method B, we use the Issue/Proposed Solution method:
 
 # Issues/Proposed Solution
 
-Team members will often want to bring up an issue and discuss it verbally.  This is both inefficient (listening takes longer than reading) and ineffective (in verbal discussions the most vocal people often have the most influence).
+Team members will often want to bring up an issue and discuss it verbally. This is both inefficient (listening takes longer than reading) and ineffective (in verbal discussions the most vocal people often have the most influence).
 
-Instead, we require that anyone who presents an issue at a team meeting do so in writing.  The write-up should include both a detailed description of the Issue as well as their Proposed Solution.  A team member asked to do a write-up might say “I don’t know the answer.”  It doesn’t matter.  They should take a guess and create a strawman.  Even if they only have 10% confidence that their answer is the right one.  And they should phrase the Proposed Solution in very bold, directive terms (“Do this ….”). This may seem aggressive, but it plants a flag in the sand which generates a much more productive discussion and a quicker decision-time, which is more important than appearing to be humble.
+Instead, we require that anyone who presents an issue at a team meeting do so in writing. The write-up should include both a detailed description of the Issue as well as their Proposed Solution. A team member asked to do a write-up might say “I don’t know the answer.” It doesn’t matter. They should take a guess and create a strawman. Even if they only have 10% confidence that their answer is the right one. And they should phrase the Proposed Solution in very bold, directive terms (“Do this ….”). This may seem aggressive, but it plants a flag in the sand which generates a much more productive discussion and a quicker decision-time, which is more important than appearing to be humble.
 
-All Issues and Proposed Solutions are presented at the weekly Team Meeting, including a pre-recording that can be replayed asynchronously at high speed to save time.  
+All Issues and Proposed Solutions are presented at the weekly Team Meeting, including a pre-recording that can be replayed asynchronously at high speed to save time.
 
-Allow up to 5 minutes of discussion for each tactical (short-term) Proposed Solution and up to 20 minutes for each strategic (long-term) Proposed Solution.  If in that time, the Decision-Maker feels that they have enough context to make a decision, they announce and write the decision. The Solution is turned into one or more Next Actions with a DRI (Directly Responsible Individual) and Due Date for each. 
+Allow up to 5 minutes of discussion for each tactical (short-term) Proposed Solution and up to 20 minutes for each strategic (long-term) Proposed Solution. If in that time, the Decision-Maker feels that they have enough context to make a decision, they announce and write the decision. The Solution is turned into one or more Next Actions with a DRI (Directly Responsible Individual) and Due Date for each.
 
 We use an Issue/Proposed Solution template to structure these issues, and typically include a recording of the issue so it can be explained quickly and concisely.
 
 If the Decision-Maker feels they don’t have enough context to make a decision, DO NOT spend more time talking about the Issue. Instead turn to the RAPID framework described below.
 
-NOTE: If all the key participants have shared their feedback asynchronusly, and it feels the key people are bought in, a decision-maker can consider making the decision asynchronously. Since the goal of an ISP is to help find blindspots, and to get buy-in, once you have that you don't need a meeting. 
+# Type 1 vs Type 2 decisions
 
-# Type 1 vs Type 2 Decisions
+A Type 1 decision is a “one-way door”. Once it’s made, it’s very difficult to reverse. Acquiring a company, or discontinuing a product line are examples of Type 1 decisions.
 
-A Type 1 decision is a “one-way door”. Once it’s made, it’s very difficult to reverse. Acquiring a company, or discontinuing a product line are examples of Type 1 decisions. 
+As organizations get larger, there’s a tendency to use the heavy-weight Type 1 decision-making process on most decisions, including many Type 2 decisions. The end result of this is slowness, unthoughtful risk aversion, failure to experiment sufficiently, and consequently diminished invention. We need to fight that tendency.
 
-As organizations get larger, there’s a tendency to use the heavy-weight Type 1 decision-making process on most decisions, including many Type 2 decisions. The end result of this is slowness, unthoughtful risk aversion, failure to experiment sufficiently, and consequently diminished invention. We need to fight that tendency. 
+Each time there is a decision to be made, rate it as Type 1 or Type 2.
 
-Each time there is a decision to be made, rate it as Type 1 or Type 2. 
+- Type 1 decisions should be made by the CEO.
+- Type 2 decisions should be made by someone who is not CEO, unless it impacts CEO-specific AORs.
 
-- Type 1 decisions should be made by the CEO. 
+Most decisions are Type 2.
 
-- Type 2 decisions should be made by someone who is not CEO, unless it impacts CEO-specific AORs. 
+# RAPID decision making
 
-Most decisions are Type 2. 
-
-# RAPID Decision-Making
-
-When a decision is complex and can’t be reached efficiently even after a well-prepared ISP, we should use a RAPID framework. This is in specific cases when: 
+When a decision is complex and can’t be reached efficiently even after a well-prepared ISP, we should use a RAPID framework. This is in specific cases when:
 
 - A team has become too large to easily get all of the needed voices in one room
 - Consensus cannot be reached within 5-20 minutes of discussion
 
-Here is an Example of a RAPID. In an Issue/Proposed Solution using RAPID: 
+Here is an Example of a RAPID. In an Issue/Proposed Solution using RAPID:
 
-1. Someone identifies an issue or decision that needs to be made.  They write up:
+1. Someone identifies an issue or decision that needs to be made. They write up:
 
   1. The Issue
   2. The Proposed Solution
@@ -112,12 +107,6 @@ Here is an Example of a RAPID. In an Issue/Proposed Solution using RAPID:
   - If the issue is urgent, the R schedules this Decision Meeting as soon as it needs to be.
   - If the issue is non-urgent, the R can use the next Team Meeting as the Decision Meeting.  (This is much more efficient, and should be done whenever the issue is non-urgent.)
 
-4. At the Decision Meeting, the D reads through the document.  If she has any questions, she asks them.  If her questions can be fully answered in 5 minutes, she decides.  If they cannot be answered in 5 minutes, she asks for another round of written responses on the document to answer her questions.  At the next Team Meeting, she reviews these responses, and decides.
+4. At the Decision Meeting, the D reads through the document. If they have any questions, they asks them. If the questions can be fully answered in 5 minutes, they decide. If the questions cannot be answered in 5 minutes, the D asks for another round of written responses on the document to answer the questions. At the next Team Meeting, the D reviews these responses, and decides.
 
-5. Once the D decides, she writes up the Decision (or asks the R to do so) along with all the Next Actions (each with a DRI and Due Date).  The D then publishes this decision to the company via the appropriate ticketing system and/or other channels
-
-
-
-
-
-
+5. Once the D decides, they write up the Decision (or asks the R to do so) along with all the Next Actions (each with a DRI and Due Date). The D then publishes this decision to the company via the appropriate ticketing system and/or other channels.

--- a/operations/operations/company-processes/issue-solution.md
+++ b/operations/operations/company-processes/issue-solution.md
@@ -2,9 +2,120 @@
 
 Issue/Solution Proposal is a tool for increasing clarity, speed, and output in teams.
 
-We're now on version three of our process. The documentation, video training, and ISP template are hosted internally [here](https://docs.google.com/document/d/17oHNwYMg_iil3HpGgg1QBIqCX4Q9KoYAyqMvjfwTiGE/edit).
-
-Over time, this page will be replaced with a [Focalboard](https://focalboard.com) page where a summary of our process and template will be hosted.
+Over time, we will be integrating ISP functionality in [Focalboard](https://focalboard.com), and unti then we will use other systems.
 
 Note: Special thanks to [Matt Mochary](https://www.linkedin.com/in/matt-mochary-34bb4/) for the framework on which this system is based.
+
+# Decision Making
+
+## Getting Buy-In 
+
+One of the core challenges in leadership is getting teams to buy into a decision intellectually and emotionally.
+
+You create buy-in when you make people feel they are part of the decision, and that their input contributes to the final outcome. The more influence they feel they have on the outcome, the more they’ll be invested in the final result.
+
+Broadly, there are three ways to make a decision. Each has a different time requirement, and creates a different level of buy-in. The methods that create the most buy-in also take the most amount of time: 
+  
+### Method A: Unilateral Decision 
+
+For a decision where there's a clear decision maker based on Areas of Responsibility (see Type 1 vs Type 2 below), the decision maker announces a decision to the team, and answers questions. This is typical when a decision is within someone’s Area of Responsibility. 
+
+Example: A digital marketer who's is responsibile for managing the executing of advertising campaigns using different vendors would make a Method A decision on which vendors to choose, and let others know. 
+
+Pros: 	
+- Takes very little time.
+Con:    	
+- Creates very little buy-in and gets no benefit from the team’s knowledge and experience. 
+
+### Method B: Issue and Proposed Solution 
+
+A Decision-Maker creates (or assigns someone to create) a written straw man (a hypothetical answer designed to inspire discussion), shares it with the team, invites team to give feedback (written and verbal), facilitates group discussion, makes everyone feel heard by repeating back their comments, and then makes a final decision.
+
+Pros: 	
+- Creates more buy-in. Gets some minimal benefit from the collective wisdom of the team.
+Con:   	
+- Takes more time.
+
+### Method C: Wallow on Strategic Issue 
+
+Decision-Maker invites a team to a meeting where a dilemma is discussed from scratch with no straw man. Team shares ideas. Decision-maker repeats back everyone’s ideas until they feel heard.  Decision-Maker shares her own idea last (because hers is the loudest voice in the room). Decision-maker makes decision.  (Note that this is not a consensus decision.  Buy-in is created by Decision-Maker confirming that she heard all ideas, not by accommodating all ideas.)
+
+Pros: 	
+- Creates the most buy-in. Gets a lot of benefit from the collective wisdom of the team.
+Con:   	
+- Takes the most time.
+ 
+Not surprisingly, the greatest benefits require the most work. If you want more buy-in and a better decision, you need to take more time in making the decision.
+
+So, which method should you use? It depends on how significant the decision is, and how important buy-in is.
+
+For everyday, low-impact issues (for example, entering a new reseller relationship), Method A is sufficient. For major, core issues (for example, Company 10-Year Vision), Method C is necessary. For everything in between (the vast majority of important decisions), Method B is optimal.
+
+For Method B, we use the Issue/Proposed Solution method: 
+
+# Issues/Proposed Solution
+
+Team members will often want to bring up an issue and discuss it verbally.  This is both inefficient (listening takes longer than reading) and ineffective (in verbal discussions the most vocal people often have the most influence).
+
+Instead, we require that anyone who presents an issue at a team meeting do so in writing.  The write-up should include both a detailed description of the Issue as well as their Proposed Solution.  A team member asked to do a write-up might say “I don’t know the answer.”  It doesn’t matter.  They should take a guess and create a strawman.  Even if they only have 10% confidence that their answer is the right one.  And they should phrase the Proposed Solution in very bold, directive terms (“Do this ….”). This may seem aggressive, but it plants a flag in the sand which generates a much more productive discussion and a quicker decision-time, which is more important than appearing to be humble.
+
+All Issues and Proposed Solutions are presented at the weekly Team Meeting, including a pre-recording that can be replayed asynchronously at high speed to save time.  
+
+Allow up to 5 minutes of discussion for each tactical (short-term) Proposed Solution and up to 20 minutes for each strategic (long-term) Proposed Solution.  If in that time, the Decision-Maker feels that they have enough context to make a decision, they announce and write the decision. The Solution is turned into one or more Next Actions with a DRI (Directly Responsible Individual) and Due Date for each. 
+
+We use an Issue/Proposed Solution template to structure these issues, and typically include a recording of the issue so it can be explained quickly and concisely.
+
+If the Decision-Maker feels they don’t have enough context to make a decision, DO NOT spend more time talking about the Issue. Instead turn to the RAPID framework described below.
+
+# Type 1 vs Type 2 Decisions
+
+A Type 1 decision is a “one-way door”. Once it’s made, it’s very difficult to reverse. Acquiring a company, or discontinuing a product line are examples of Type 1 decisions. 
+
+As organizations get larger, there’s a tendency to use the heavy-weight Type 1 decision-making process on most decisions, including many Type 2 decisions. The end result of this is slowness, unthoughtful risk aversion, failure to experiment sufficiently, and consequently diminished invention. We need to fight that tendency. 
+
+Each time there is a decision to be made, rate it as Type 1 or Type 2. 
+
+- Type 1 decisions should be made by the CEO. 
+
+- Type 2 decisions should be made by someone who is not CEO, unless it impacts CEO-specific AORs. 
+
+Most decisions are Type 2. 
+
+# RAPID Decision-Making
+
+When a decision is complex and can’t be reached efficiently even after a well-prepared ISP, we should use a RAPID framework. This is in specific cases when: 
+
+- A team has become too large to easily get all of the needed voices in one room
+- Consensus cannot be reached within 5-20 minutes of discussion
+
+Here is an Example of a RAPID. In an Issue/Proposed Solution using RAPID: 
+
+1. Someone identifies an issue or decision that needs to be made.  They write up:
+
+  1. The Issue
+  2. The Proposed Solution
+  3. The list of people needed to make and implement the decision:
+    - R (Recommend) = the one who first proposed the Issue and Solution
+    - A (Agree) = those people whose input must be incorporated in the decision. This is typically blank, unless is is the legal team to ensure no one is breaking the law. It should be very rare that anyone else's agreement is required for a decision. 
+    - P (Perform) = those people who will have to enact any decision and therefore should be heard
+    - I (Input) = those people whose input is worth considering
+    - D (Decide) = the one who will make the decision. 
+      - If Type 1, this should be the CEO.
+      - If Type 2, this should be someone other than the CEO.
+  4. A section on the document for each person above to write their comments.
+
+2. The R then reaches out to all the As, Ps and Is to solicit their input. Once this input is received, the document is ready to be reviewed by the D.
+
+3. The R schedules a Decision Meeting and invites the D, As, Is and Ps.
+  - If the issue is urgent, the R schedules this Decision Meeting as soon as it needs to be.
+  - If the issue is non-urgent, the R can use the next Team Meeting as the Decision Meeting.  (This is much more efficient, and should be done whenever the issue is non-urgent.)
+
+4. At the Decision Meeting, the D reads through the document.  If she has any questions, she asks them.  If her questions can be fully answered in 5 minutes, she decides.  If they cannot be answered in 5 minutes, she asks for another round of written responses on the document to answer her questions.  At the next Team Meeting, she reviews these responses, and decides.
+
+5. Once the D decides, she writes up the Decision (or asks the R to do so) along with all the Next Actions (each with a DRI and Due Date).  The D then publishes this decision to the company via the appropriate ticketing system and/or other channels
+
+
+
+
+
 

--- a/operations/operations/company-processes/issue-solution.md
+++ b/operations/operations/company-processes/issue-solution.md
@@ -67,6 +67,8 @@ We use an Issue/Proposed Solution template to structure these issues, and typica
 
 If the Decision-Maker feels they don’t have enough context to make a decision, DO NOT spend more time talking about the Issue. Instead turn to the RAPID framework described below.
 
+NOTE: If all the key participants have shared their feedback asynchronusly, and it feels the key people are bought in, a decision-maker can consider making the decision asynchronously. Since the goal of an ISP is to help find blindspots, and to get buy-in, once you have that you don't need a meeting. 
+
 # Type 1 vs Type 2 Decisions
 
 A Type 1 decision is a “one-way door”. Once it’s made, it’s very difficult to reverse. Acquiring a company, or discontinuing a product line are examples of Type 1 decisions. 


### PR DESCRIPTION
We used to have a private G Doc with the Decision Making information, it's not proprietary, so we should make it open: https://docs.google.com/document/d/1e1RDy8GO9RgcqCw54CmzPnu84rhOqKKrNNDyVoFH9-k/edit

Once the handbook is updated we should re-direct the G Doc to the handbook

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
