### PR TITLE
update CLA/contributor agreement link from .org to .com

### DIFF
--- a/company/how-to-guides-for-staff/how-to-update-handbook.md
+++ b/company/how-to-guides-for-staff/how-to-update-handbook.md
@@ -25,7 +25,7 @@ The Handbook is a public-facing body of work and although it's a constantly-evol
 
 ## Getting started
 
-If this is your first time contributing to Mattermost, first read the [Mattermost Contributor Agreement](https://www.mattermost.org/mattermost-contributor-agreement/) and sign it \(at the bottom of the page\), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true). Please ensure the **GitHub username** field matches your GitHub username exactly, including capitalization.
+If this is your first time contributing to Mattermost, first read the [Mattermost Contributor Agreement](https://www.mattermost.com/mattermost-contributor-agreement/) and sign it \(at the bottom of the page\), so you can be added to the Mattermost [Approved Contributor List](https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true). Please ensure the **GitHub username** field matches your GitHub username exactly, including capitalization.
 
 Then, please request access to the Mattermost organization [DevOps Team Channel](https://community.mattermost.com/private-core/channels/devops-team). This means that you can edit the files in the Handbook repo and not have to create a fork for your changes.
 


### PR DESCRIPTION
Changed LN 28 link from .org to .com
https://www.mattermost.org/mattermost-contributor-agreement/ to https://www.mattermost.com/mattermost-contributor-agreement/

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: http://www.mattermost.org/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
