### PR TITLE
Add item for reviewing titles/levels sheet in engineering onboarding guideline

### DIFF
--- a/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding.md
+++ b/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding.md
@@ -49,6 +49,7 @@ This is the general timeline and expectations for new engineers starting at Matt
   * Go over core values and Leadership Principles with dev lead
 * Work on 1 - 3 small tickets
 * Introduction at the [Customer Obsession Meeting](https://handbook.mattermost.com/operations/operations/company-cadence#customer-obsession-meeting-aka-com)
+* Review the [Engineering Titles/Levels](https://docs.google.com/spreadsheets/d/11pG9OqsLTltVylGRDBUOcTa65kkHd_EtRiPBz8Mnnpk/edit#gid=2064417787) sheet to understand expectations and responsibilities for your level
 
 ## Weeks 3 - 4: Focus on solidifying role in the team
 

--- a/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding.md
+++ b/operations/workplace/people/working-at-mattermost/onboarding/engineer-onboarding.md
@@ -49,7 +49,6 @@ This is the general timeline and expectations for new engineers starting at Matt
   * Go over core values and Leadership Principles with dev lead
 * Work on 1 - 3 small tickets
 * Introduction at the [Customer Obsession Meeting](https://handbook.mattermost.com/operations/operations/company-cadence#customer-obsession-meeting-aka-com)
-* Review the [Engineering Titles/Levels](https://docs.google.com/spreadsheets/d/11pG9OqsLTltVylGRDBUOcTa65kkHd_EtRiPBz8Mnnpk/edit#gid=2064417787) sheet to understand expectations and responsibilities for your level
 
 ## Weeks 3 - 4: Focus on solidifying role in the team
 
@@ -61,6 +60,7 @@ This is the general timeline and expectations for new engineers starting at Matt
 * Meet with dev lead
   * Meet once a week and start regular weekly 1-1s
 * Work on some medium size tickets
+* Review the [Engineering Titles/Levels](https://docs.google.com/spreadsheets/d/11pG9OqsLTltVylGRDBUOcTa65kkHd_EtRiPBz8Mnnpk/edit#gid=2064417787) sheet to understand expectations and responsibilities for your level
 
 ## Weeks 5 - 8 \(Month 2\): Work on your first project as dev owner
 


### PR DESCRIPTION
#### Summary
As a part of engineer onboarding we didn't have an item for getting them familiar with the title/levels sheet. I think it's pretty important that new engineers are at least aware of it early on, even if they're more were worried about onboarding and getting up to speed.