### PR TITLE
Add gifting policy to handbook

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -196,6 +196,7 @@
     * [How to spend company money: Internships](operations/finance/staff-member-expenses/internship-expense-policy.md)
     * [Corporate credit card policy](operations/finance/staff-member-expenses/corporate-credit-card-policy.md)
     * [How to use Expensify](operations/finance/staff-member-expenses/how-to-use-expensify.md)
+    * [Gifting policy](operations/finance/staff-member-expenses/gifting-policy.md)
     * [How to book airfare and travel](operations/finance/staff-member-expenses/airfare-and-traveling.md)
     * [How to reimburse the company](operations/finance/staff-member-expenses/how-to-reimburse-the-company.md)
     * [How to convert currencies](operations/finance/staff-member-expenses/currency-exchange-table.md)

--- a/operations/finance/staff-member-expenses/gifting-policy.md
+++ b/operations/finance/staff-member-expenses/gifting-policy.md
@@ -1,6 +1,6 @@
 # Gifting Policy
 
-If you attend a call to share feedback for a tool that Mattermost uses or may use, you may be offered a "gift" in exchange for sharing your feedback. The gift could be monetary (e.g. a $50 gift card), or a physical item (e.g. AirPod Pros).
+If you attend a call to share feedback for a tool that Mattermost uses or may use, you may be offered a "gift" in exchange for sharing your feedback. The gift could be merchant credits (e.g. a $50 gift card), or a physical item (e.g. AirPod Pros).
 
 Before accepting this gift, please reach out to Expenses@mattermost.com. The accounting team will help assess whether the gift falls under taxable income. The tax rules for gifts depend on your country/region of residence and the value of the gift offered to you.
 

--- a/operations/finance/staff-member-expenses/gifting-policy.md
+++ b/operations/finance/staff-member-expenses/gifting-policy.md
@@ -1,0 +1,7 @@
+# Gifting Policy
+
+If you attend a call to share feedback for a tool that Mattermost uses or may use, you may be offered a "gift" in exchange for sharing your feedback. The gift could be monetary (e.g. a $50 gift card), or a physical item (e.g. AirPod Pros).
+
+Before accepting this gift, please reach out to Expenses@mattermost.com. The accounting team will help assess whether the gift falls under taxable income. The tax rules for gifts depend on your country/region of residence and the value of the gift offered to you.
+
+If any questions or concerns, please reach out to Expenses@mattermost.com, or the Finance Team channel on Mattermost.


### PR DESCRIPTION
This is a summary of our gifting policy, providing guidance to our team members on what actions to take if they are offered a gift in exchange of sharing feedback on a tool we use, or may consider using in the future.