### PR TITLE
Remove recommended readings link

### DIFF
--- a/operations/finance/staff-member-expenses/how-to-spend-company-money.md
+++ b/operations/finance/staff-member-expenses/how-to-spend-company-money.md
@@ -41,7 +41,6 @@ While we're sharing average costs for various items below, you should use your b
 * Laptop stand: Average price **180 USD**
 * Laptop carrying bag: Average price **60 USD**
 * Work-related books: **30 USD** per month or **360 USD** annually
-  * Recommended [readings](https://docs.mattermost.com/process/training.html#books)
 
 #### Business computer accessories
 

--- a/operations/finance/staff-member-expenses/how-to-spend-company-money.md
+++ b/operations/finance/staff-member-expenses/how-to-spend-company-money.md
@@ -41,6 +41,7 @@ While we're sharing average costs for various items below, you should use your b
 * Laptop stand: Average price **180 USD**
 * Laptop carrying bag: Average price **60 USD**
 * Work-related books: **30 USD** per month or **360 USD** annually
+  * [Recommended resources](https://handbook.mattermost.com/operations/research-and-development/training)
 
 #### Business computer accessories
 


### PR DESCRIPTION
Recommended readings link doesn't go anywhere, I searched for an alternative in the handbook, but there is no alternative page in terms of books or readings, so I'd say let's remove it until there is something to link there. WDYT?

Thank you!

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: https://mattermost.com/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.com/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
