### PR TITLE
address some typos in handbook

### DIFF
--- a/company/about-mattermost/business-model.md
+++ b/company/about-mattermost/business-model.md
@@ -12,7 +12,7 @@ We deliver our solutions through an open core, product-led growth motion with fr
 
 Analysts project that in 2022, over $4.5 trillion USD will be spent on IT. What portion of that investment turns into productivity and results depends entirely on how well teams of software builders and operators can effectively collaborate.
 
-Mattermost competes in a $15B market for "developer collaboration", a segment of the boarder general collaboration market focused on accelerating developer productivity through agile workflows across application development, digital operations and security operations. Our focus is serving a market of 30 million developers with an integrated, open core collaboration suite across workplace messaging, project management, incident management, real time communication, and documentation available both in cloud and as a self-hosted component of an organization's digital infrastructure.
+Mattermost competes in a $15B market for "developer collaboration", a segment of the broader general collaboration market focused on accelerating developer productivity through agile workflows across application development, digital operations and security operations. Our focus is serving a market of 30 million developers with an integrated, open core collaboration suite across workplace messaging, project management, incident management, real time communication, and documentation available both in cloud and as a self-hosted component of an organization's digital infrastructure.
 
 Many of these organizations are facing three critical challenges:
 

--- a/company/about-mattermost/mindsets.md
+++ b/company/about-mattermost/mindsets.md
@@ -154,7 +154,7 @@ A good analysis will result in surprises uncovering blindspots. An analysis that
 
 ## RAPID for Complex Projects
 
-When practical, projects and decision making should be run at the lowest possible level of the organization, by people who are closest to the facts and data.
+When practical, projects and decision-making should be run at the lowest possible level of the organization, by people who are closest to the facts and data.
 
 When a project is complex and involves many stakeholders, a different approach may be needed. We use a RAPID framework for complex, multi-stakeholder projects where clarity in the roles of stakeholders is vital.
 

--- a/company/how-to-guides-for-staff/how-to-update-handbook.md
+++ b/company/how-to-guides-for-staff/how-to-update-handbook.md
@@ -21,7 +21,7 @@ The Handbook is a public-facing body of work and although it's a constantly-evol
 
 * **Be concise:** Say what's essential, not more.
 * **Get feedback:** Have someone from your target audience read your draft to share feedback so you can [savor surprises](../about-mattermost/mindsets.md#savor-surprises).
-* **Don't aim for perfection:** Our goal is regular iteration and so your content doesn't have to be perfect before it's published. It will be reviewed by an editor prior to publication so any major errors will be addressed then.
+* **Don't aim for perfection:** Our goal is regular iteration, so your content doesn't have to be perfect before it's published. It will be reviewed by an editor prior to publication so any major errors will be addressed then.
 
 ## Get started
 

--- a/operations/operations/company-processes/issue-solution.md
+++ b/operations/operations/company-processes/issue-solution.md
@@ -4,7 +4,7 @@ Issue/Solution Proposal is a tool for increasing clarity, speed, and output in t
 
 Note: Special thanks to [Matt Mochary](https://www.linkedin.com/in/matt-mochary-34bb4/) for the framework on which this system is based.
 
-# Decision making
+# Decision-making
 
 ## Getting buy-in
 
@@ -68,7 +68,7 @@ Allow up to 5 minutes of discussion for each tactical (short-term) Proposed Solu
 
 We use an Issue/Proposed Solution template to structure these issues, and typically include a recording of the issue so it can be explained quickly and concisely.
 
-If the decision maker feels they don’t have enough context to make a decision, DO NOT spend more time talking about the Issue. Instead turn to the RAPID decision making framework described below.
+If the decision maker feels they don’t have enough context to make a decision, DO NOT spend more time talking about the Issue. Instead turn to the RAPID decision-making framework described below.
 
 # Type 1 vs Type 2 decisions
 
@@ -83,7 +83,7 @@ Each time there is a decision to be made, rate it as Type 1 or Type 2.
 
 Most decisions are Type 2.
 
-# RAPID decision making
+# RAPID decision-making
 
 When a decision is complex and can’t be reached efficiently even after a well-prepared ISP, we should use a RAPID framework. This is in specific cases when:
 

--- a/operations/research-and-development/product/product-planning/product-philosophy-and-principles.md
+++ b/operations/research-and-development/product/product-planning/product-philosophy-and-principles.md
@@ -12,7 +12,7 @@ We **Earn Trust**. We welcome input from all members of the core staff and commu
 
 ## MVP and Iteration
 
-We are **Self-Aware** and work on **High Impact** changes. We use data in our decision making processes. By developing an MVP \(minimum viable product\) of a solution, we can gather more data to inform our future work; thereby allowing us to create solutions for real pains. A MVP may include providing a prototype or a partial solution so we can collect feedback in the most realistic scenarios. We try to ship the smallest thing as quickly as possible and learn from it, so we make sure what we are building is going to create the value expected by our customers.
+We are **Self-Aware** and work on **High Impact** changes. We use data in our decision-making processes. By developing an MVP \(minimum viable product\) of a solution, we can gather more data to inform our future work; thereby allowing us to create solutions for real pains. A MVP may include providing a prototype or a partial solution so we can collect feedback in the most realistic scenarios. We try to ship the smallest thing as quickly as possible and learn from it, so we make sure what we are building is going to create the value expected by our customers.
 
 ## Quality is a first class citizen
 


### PR DESCRIPTION
#### Summary

I'm reading through the handbook in hopes of contributing during Hacktoberfest, and this PR contains any small typo fixes I've noticed.

- "Boarder" should be "broader" based on the context present
- Consider using "decision-making" consistently rather than "decision making" in some places and "decision making" in others.