### PR TITLE
Create product-design-ownership-area

### DIFF
--- a/operations/research-and-development/product/product-design-team-handbook/product-design-ownership-areas
+++ b/operations/research-and-development/product/product-design-team-handbook/product-design-ownership-areas
@@ -1,0 +1,15 @@
+# Product Design Areas of Ownership
+
+| Product Area | Example Features | Design Owner |
+| :--- | :--- | :--- |
+| Channels | Chat, Search, Notifications, Status, User Settings, Onboarding, Mobile | Matt Birtch |
+| Playbooks | Incident Response Colloboration, Checklists, Retrospectives | Abhijit Singh |
+| Boards | Boards, Tasks, Focalboard | Asaad Mahmood |
+| Calls | Audio & Video Calls | Tanmay Singh |
+| Apps & Integrations | Plugins, Apps, Apps Marketplace, Apps & Plugin Framework | Matt Birtch|
+| Growth | Product-led growth, Trials, In-product & Email Nurtures, Packaging & Pricing, A/B Testing Framework | Anneliese Klein |
+| Self-Service | Upgrade/Downgrade Path, Billing, Purchases/Customer Portal, Licenses | Anneliese Klein |
+| Users & Teams | User Invite, User Sign-in/Authentication, User Roles, User & Team Management, User Groups, User Settings| Anna Pohorielova|
+| Compass | Design system | Michael Gamble |
+
+For a comprehensive list of ownership areas, please see [this document](https://docs.google.com/document/d/1E1JvtBZs-9D6QEbwm4sLO9SyqSPrHUvrD-V0yvxoOPE/edit?usp=sharing).

--- a/operations/research-and-development/product/product-design-team-handbook/product-design-ownership-areas.md
+++ b/operations/research-and-development/product/product-design-team-handbook/product-design-ownership-areas.md
@@ -1,11 +1,11 @@
-# Product Design Areas of Ownership
+# Product Design areas of ownership
 
-| Product Area | Example Features | Design Owner |
+| Product area | Example features | Design owner |
 | :--- | :--- | :--- |
-| Channels | Chat, Search, Notifications, Status, User Settings, Onboarding, Mobile | Matt Birtch |
-| Playbooks | Incident Response Colloboration, Checklists, Retrospectives | Abhijit Singh |
+| Channels | Chat, Search, Notifications, Status, User settings, Onboarding, Mobile | Matt Birtch |
+| Playbooks | Incident response colloboration, Checklists, Retrospectives | Abhijit Singh |
 | Boards | Boards, Tasks, Focalboard | Asaad Mahmood |
-| Calls | Audio & Video Calls | Tanmay Singh |
+| Calls | Audio & video calls | Tanmay Singh |
 | Apps & Integrations | Plugins, Apps, Apps Marketplace, Apps & Plugin Framework | Matt Birtch|
 | Growth | Product-led growth, Trials, In-product & Email Nurtures, Packaging & Pricing, A/B Testing Framework | Anneliese Klein |
 | Self-Service | Upgrade/Downgrade Path, Billing, Purchases/Customer Portal, Licenses | Anneliese Klein |


### PR DESCRIPTION
Adding the product design ownership areas for each of the designers

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: https://mattermost.com/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.com/t/limited-edition-mattermost-mugs/143
-->

#### Summary
<!--
A description of what this pull request does.
-->
