### PR TITLE
Added communication principles

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -273,6 +273,7 @@
     * [Contribution events](contributors/contributors/contribution-events.md)    
   * [Mattermost community](contributors/contributors/community.md)
   * [Contributor kindness](contributors/contributors/contributor-kindness.md)
+  * [Communication Principles](contributors/contributors/communication-principle.md)
   * [Community systems](contributors/contributors/community-systems.md)
   * [Guidelines and playbooks](contributors/contributors/guidelines/README.md)
     * [Social engagement guidelines](contributors/contributors/guidelines/social-engagement-guidelines.md)

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -273,7 +273,7 @@
     * [Contribution events](contributors/contributors/contribution-events.md)    
   * [Mattermost community](contributors/contributors/community.md)
   * [Contributor kindness](contributors/contributors/contributor-kindness.md)
-  * [Communication Principles](contributors/contributors/communication-principle.md)
+  * [Communication Principles](contributors/contributors/communication-principles.md)
   * [Community systems](contributors/contributors/community-systems.md)
   * [Guidelines and playbooks](contributors/contributors/guidelines/README.md)
     * [Social engagement guidelines](contributors/contributors/guidelines/social-engagement-guidelines.md)

--- a/contributors/contributors/communication-principle.md
+++ b/contributors/contributors/communication-principle.md
@@ -1,0 +1,18 @@
+# Communication Principle
+
+As we share ideas and communicate within the community, we want to ensure that communication principles are followed. 
+You can have a look at the set within the Mattermost Community, there are instructions that fall under the Communication Principle.
+
+## Sharing the Right Information
+
+With contributors communicating with one another, we expect everyone to validate a piece of information before sharing it with others. 
+Also ensure that the right information is shared at the right time, in the right context, and with the right audience.
+
+## Speaking in the Right Manner
+
+If you wish to convey information within the community, do so clearly, kindly, concisely, and in an international manner to ensure no problems arise.
+
+## Reacting in the Right Manner
+
+Celebrate your accomplishments and those of others in your community. As you deal with issues, double-check and alert accordingly.
+

--- a/contributors/contributors/communication-principles.md
+++ b/contributors/contributors/communication-principles.md
@@ -1,4 +1,4 @@
-# Communication Principle
+# Communication Principles
 
 As we share ideas and communicate within the community, we want to ensure that communication principles are followed. 
 You can have a look at the set within the Mattermost Community, there are instructions that fall under the Communication Principle.


### PR DESCRIPTION
Fix: https://github.com/mattermost/mattermost-handbook/issues/104

Communication principles are added to the "contributors" section in Mattermost Handbook.

(Being a first-time contributor, I have signed the Mattermost CLA)