### PR TITLE
References for FY24 Planning

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -42,7 +42,7 @@
       * [Post-publication quality control process](operations/operations/company-processes/publishing/quality-control-process.md)
   * [Handbook processes and policies](operations/operations/handbook/README.md)
     * [Handbook onboarding](operations/operations/handbook/handbook-onboarding.md)
-  * [Previous fiscal year information](operations/operations/previous-fiscal-year-information.md)
+  * [Fiscal year planning](operations/operations/fiscal-year-planning.md)
 * [Research and Development](operations/research-and-development/README.md)
   * [Organization](operations/research-and-development/organization/README.md)
     * [Channels](/operations/research-and-development/organization/channels.md)

--- a/operations/operations/fiscal-year-planning.md
+++ b/operations/operations/fiscal-year-planning.md
@@ -1,0 +1,18 @@
+Mattermost fiscal year ends on January 31.
+
+As part of the yearly planning, we use various documents as references. 
+
+Below is a list of references used for FY24 Strategy & Plan (link to be added).
+
+- [Nov 2022 COM Presentation of Thematic Goal & Defining Objectives](https://docs.google.com/presentation/d/19shfHNoUMs4Z-lS_eh7Qh65jE54ZYQbQQHFhqRvQpFo/edit#slide=id.g19c6ca47425_0_992)
+- [FY24 Message House](https://docs.google.com/document/u/1/d/1IZUL74p6qAQJvduOrElzJbZtLbyAIkRJQdQ8v1iObvU/edit)
+- [FY24 Pricing & Packaging Principles](https://docs.google.com/document/d/1pKxiEevyM_dVb2MKoa-m50ZC_t6zCZ4vntGBbfazG1s/edit)
+- [FY24 Product Editions & Plans](https://docs.google.com/document/d/1bAsnfCRsp23d30FEMLluf0zcpvsizTAme_acZ4PdSOc/edit#)
+- [FY24 Company-Level Goal Tracker](https://docs.google.com/spreadsheets/d/1n_BShB_rrn3kNx0vCgQ-hnf4ZaRsnjz8ZT7UCEFTZ_4/edit#gid=311756856)
+- [FY24 Prioritization Worksheet](https://docs.google.com/spreadsheets/d/1epHwKC6QgcruA1aajbRX-Z8oA81KNDiQTECrOX9uJ1g/edit#gid=1080622947)
+- [FY23 Strategy and Plan](https://docs.google.com/document/d/1Rq3hPLXLrmA5wTAacDkDjySZrpdYpf2zX-3lm3ymxV4/edit#heading=h.az0lixiueeoa)
+- [Simon & Kutcher Final Packaging Readout](https://drive.google.com/file/d/1xtTbp6n6SdyToEs35gefBMSWFOwRHWng/view)
+- [Simon & Kutcher Full Packaging Deck](https://docs.google.com/presentation/d/1yhzgrF07dof04HWKDeftnEHZgwK--asl-mhJpaj31JA/edit#slide=id.p)
+- [Redpoint metrics template](https://docs.google.com/spreadsheets/d/1cdtqPcEcpP9lxqrOINH_FsxF8HBzaE6oKtAU9kPr6-k/edit#gid=0)
+- [MLX Areas of Responsibility](https://community.mattermost.com/boards/team/qghzt68dq7bopgqamcnziq69ao/bxekuo4ea9tn5b8jpj3zzogtfuh/vqdsdwgjnm7bsbd7cbukwknut9a)
+- [Acronyms](https://handbook.mattermost.com/company/about-mattermost/list-of-terms)


### PR DESCRIPTION
New page to list key references used for FY24 strategy & plan, as additional context for staff, and also as reference for FY25 planning next year.

We will supplement with the final FY24 strategy & plan doc.

cc @amynicol1985 please add any other key references worth including
cc @justinegeffen for editor review