### PR TITLE
Add Product Vulnerability process to ToC

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -217,6 +217,7 @@
     * [Data deletion requests](operations/security/privacy/data-deletion-requests.md)
     * [Data subject access requests](operations/security/privacy/data-subject-access-requests.md)
   * [Product Security](operations/security/product-security/README.md)
+    * [Product Vulnerability Process](operations/security/product-security/product-vulnerability-process.md)
     * [Working on security-sensitive pull requests](operations/security/product-security/working-on-sensitive-prs.md)
     * [Secure Software Development guide](operations/research-and-development/product/development-process/secure-software-development.md)
   * [Security Operations](operations/security/security-operations/README.md)


### PR DESCRIPTION
#### Summary
The Product vulnerability process was added in #1198. This PR adds it to the Table of Contents so that it can appear in https://handbook.mattermost.com/ 