### PR TITLE
Update pql.md

### DIFF
--- a/operations/research-and-development/product/growth/pql.md
+++ b/operations/research-and-development/product/growth/pql.md
@@ -4,6 +4,6 @@ A workspace / instance is considered a Product Qualified Lead (PQL) if it is act
 
 | PQL Categories      | Criteria |
 | ----------- | ----------- |
-| Hand Raisers      | Either/or: <br> - Requested to get in touch with sales / request a quote <br> - Activated an enterprise trial|
+| Hand Raisers      | Either/or: <br> - Requested to get in touch with sales / request a quote <br> - Activated an enterprise trial (self-hosted only)|
 | Upgrade action   | Workspace that self-serve upgrades to a Professional plan        |
 | Usage-Based | Either/or: <br> - 25 Daily Active Users (DAU) <br> - 2,000 posts


### PR DESCRIPTION
Updated definition to remove "trial start" as a product-qualifying activity. This is to adapt to the fact that all Cloud workspaces will start a trial from day 0.