### PR TITLE
Remove duplicate item in product vuln doc

### DIFF
--- a/operations/security/product-security/product-vulnerability-process.md
+++ b/operations/security/product-security/product-vulnerability-process.md
@@ -105,7 +105,6 @@ Vulnerabilities must be assigned one of the following vulnerability types:
 * [CWE-922: Insecure Storage of Sensitive Information](https://cwe.mitre.org/data/definitions/922.html)
 * [CWE-319: Cleartext Transmission of Sensitive Information](https://cwe.mitre.org/data/definitions/319.html)
 * [CWE-327: Use of a Broken or Risky Cryptographic Algorithm](https://cwe.mitre.org/data/definitions/327.html)
-* [CWE-74: Improper Neutralization of Special Elements in Output Used by a Downstream Component ('Injection')](https://cwe.mitre.org/data/definitions/74.html)
 * [CWE-918: Server-Side Request Forgery (SSRF)](https://cwe.mitre.org/data/definitions/918.html)
 
 ### Backport Policy


### PR DESCRIPTION
#### Summary

There's a duplicate item in the "Issue Types" section of the product vulnerability docs. This PR removes the second one that appears there.