### PR TITLE
Markdown typo on R&D Calendar page

### DIFF
--- a/operations/research-and-development/organization/README.md
+++ b/operations/research-and-development/organization/README.md
@@ -80,5 +80,5 @@ The calendar will not "accept" the invite by default, with the invitation showin
 **Before Accepting**
 ![Not yet accepted](../../../.gitbook/assets/rnd-calendar-not-yet-accepted.png)
 
-**After Accepting::
+**After Accepting**
 ![Accepted](../../../.gitbook/assets/rnd-calendar-accepted.png)


### PR DESCRIPTION
#### Summary
Fix a markdown typo on https://handbook.mattermost.com/operations/research-and-development/organization#calendar:

<img width="532" alt="image" src="https://user-images.githubusercontent.com/1023171/235967002-21ccba87-a386-4ddd-b564-60d7429165ce.png">
