### PR TITLE
Add clear CTAs at the top of partner program page

### DIFF
--- a/operations/sales/partner-programs.md
+++ b/operations/sales/partner-programs.md
@@ -1,5 +1,11 @@
 # Partner Programs
 
+**Ready to place an order?** [Complete our deal registration form](https://mattermost.com/reseller-deal-registration/) to be eligible for a reseller discount.
+
+**Ready to become a Mattermost partner?** [Contact us](https://mattermost.com/contact-us) with a request to become a Mattermost partner under one of the programs listed below. If applicable, include the name of the customer to which you would like to resell.
+
+------
+
 Mattermost offers multiple partner programs:
 
 * Mattermost Authorized Reseller Program for one-time resale transactions fulfilling customer request to reseller.


### PR DESCRIPTION
Adding clear CTAs to
1. Register deals in exchange for a partner discount.
2. Applying to our partner program (for now a contact sales form, later we may have a separate form for partner applications)

cc @hannaparks for visibility on two changes - we'd probably want to do an overhaul of our partner handbook, but this change makes it easier for partners to get started.