### PR TITLE
Adjust information used for partner directory listings

### DIFF
--- a/operations/sales/partner-programs.md
+++ b/operations/sales/partner-programs.md
@@ -96,9 +96,9 @@ After completion of a partner agreement, partners are invited to send an overvie
 To get started, please email the following to partner-directory@mattermost.com:
 
 * **Partner Name:** Your legal name may be shortened to fit in the directory listing. If you wish you can state your full legal name as part of your partner description.
-* **Partner Contact Information:** The best email address \(and phone number, if preferred\) where you can be reached.
 * **Partner Description:** Between 30-100 words describing your business. See examples at [https://mattermost.com/partners/](https://mattermost.com/partners/).
 * **City, State/Province, and Country:** Location of key office or offices providing Mattermost services, or global headquarters.
+* **Website:** URL of main website for your organization.
 * **Logo:** At least 200px wide.
 
 If you have joined the Value-Added Reseller program, your reseller territory will appear in the listing as well.


### PR DESCRIPTION
Replace partner contact information with a link to their website instead