### PR TITLE
SecOps Team Roster Update

### DIFF
--- a/operations/security/README.md
+++ b/operations/security/README.md
@@ -28,6 +28,3 @@ Email:
 * Paul Harrison, Security Engineering Lead
 * Ailsa Partridge, Security Engineer II
 * Corey Robinson, Security Engineer II
-* Jorge Blanco, Senior Security Engineer
-* Joseba Astoreca, Security Engineer II
-


### PR DESCRIPTION
Clean-up of SecOps team members.

<!-- Thank you for contributing a pull request! Here are a few tips to help you:

1. Learn how to update the handbook: https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-update-handbook
2. If this is your first contribution, please sign the Contributor License Agreement: https://mattermost.com/mattermost-contributor-agreement/
   - Once signed, you will be added to the Mattermost Approved Contributor List: https://docs.google.com/spreadsheets/d/1NTCeG-iL_VS9bFqtmHSfwETo5f-8MQ7oMDE5IUYJi_Y/pubhtml?gid=0&single=true
   - If you included your mailing address, you may receive a Limited Edition Mattermost Mug as a thank you gift after your pull request is merged: https://forum.mattermost.com/t/limited-edition-mattermost-mugs/143
-->

#### Summary
Removing two former Mattermost staff from the Security README.
