### PR TITLE
Create hardware-&-software-purchases

### DIFF
--- a/operations/workplace/it/hardware-&-software-purchases
+++ b/operations/workplace/it/hardware-&-software-purchases
@@ -108,4 +108,49 @@ If you are seeking to test a new software and it is not a material cost or comit
 
 Note that any software expensed that has not been vetted through Procurement will not be reimbursed. Should you have questions, reach out to the [Purchases](https://community.mattermost.com/private-core/channels/purchases) channel.
 
+### Approved Vendors
+
+The approved vendor list is a list of vendors IT has reviewed and approved for work use based on our Legal and Security compliance requirements. We understand that there may be a product you would like to use as a part of your work setup, the current list is not a hard limit. If a vendor you wish to purchase is not listed, please open an [IT ticket](https://helpdesk.mattermost.com/) and the IT team will review, make a determination, and if approved add the vendor to the whitelist. 
+
+Please see the current list of approved vendors below:
+
+* Apple
+* Anker
+* APC
+* Amazon Basics
+* Acer
+* Asus
+* Audio Technica
+* Bose
+* BenQ
+* Corsair
+* Cisco
+* Dell
+* DisplayLink
+* Gigabyte
+* Intel
+* JBL
+* Jabra
+* Lenovo
+* Logitech
+* LG
+* Microsoft
+* MSI
+* Netgear
+* Panasonic
+* Philips
+* Razer
+* Rode
+* Shure
+* Skullcandy
+* Satechi
+* Startech
+* SteelSeries
+* Samsung
+* Sennheiser
+* Sony
+* Targus
+* Toshiba
+* Ugreen
+
 

--- a/operations/workplace/it/hardware-&-software-purchases
+++ b/operations/workplace/it/hardware-&-software-purchases
@@ -1,0 +1,111 @@
+# Hardware & Software Purchases
+
+### Computer and technology guidelines
+
+#### Laptop \(business computer\)
+
+For all new staff members, to request a new laptop, please use this [form](https://docs.google.com/forms/d/e/1FAIpQLSe7DV-dt1K4G2UtVszjK78iRZD5i_ubhRk3xkUKnEemcyyELw/viewform). We realize laptops are the most vital company equipment to be successful at Mattermost, please choose what you need to do your best work. If you require a laptop outside of the normal specifications of what we provide by default, please reach out to IT@mattermost.com with the details of the request.
+
+**Non-engineers**
+
+* **Windows:** We will provide a [XPS 15](https://www.dell.com/en-us/shop/dell-laptops/xps-15-laptop/spd/xps-15-9530-laptop/usexcpcto9530rpl05) or similar. General specs are i9, 32GB memory, 1TB SSD.
+* **Mac:** We will provide a [14" Macbook Pro](https://www.apple.com/shop/buy-mac/macbook-pro/14-inch-space-black-apple-m3-pro-with-11-core-cpu-and-14-core-gpu-18gb-memory-512gb) or similar. General specs are M3 Pro 11-core CPU, 14-core GPU, 16-core Neural Engine, 36GB memory, 512GB SSD.
+
+**Engineers**
+
+* **Windows:** We will provide a [XPS 15](https://www.dell.com/en-us/shop/dell-laptops/xps-15-laptop/spd/xps-15-9530-laptop/usexcpcto9530rpl05) or similar. General specs are i9, 64GB memory, 1TB SSD.
+* **Mac:** We will provide a [16" Macbook Pro](https://www.apple.com/shop/buy-mac/macbook-pro/16-inch-space-black-apple-m3-max-with-16-core-cpu-and-40-core-gpu-48gb-memory-1tb) or similar. General specs are M3 Max 16-core CPU, 40-core GPU, 16-core Neural Engine, 64GB memory, 1TB SSD.
+
+**Designers**
+
+* **Mac:** We will provide a [16" Macbook Pro](https://www.apple.com/shop/buy-mac/macbook-pro/16-inch-space-black-apple-m3-max-with-16-core-cpu-and-40-core-gpu-48gb-memory-1tb) or similar. General specs are M3 Max 16-core CPU, 40-core GPU, 16-core Neural Engine, 64GB memory, 1TB SSD.
+
+Once you've received your laptop, you're required to register it by completing an [Asset Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSfesCJ-XMvXjBxeAYJxvzzbvZHnSv2rH9I48IioJrURNhd7Eg/viewform). This step should be completed within 5 business days after your laptop was received.
+
+#### Desktop \(business computer\)
+
+Desktops may be requested alongside a laptop for **engineering** roles. To request a desktop, email a request to your manager with the subject `Desktop for Approval`. Include IT for approval tracking by cc'ing daniel.sischy@mattermost.com. If your manager approves, a request should be sent to Joram Wilander, Director of Engineering, for budget review and need. If you receive both approvals, you may formally request a desktop through the [Desktop Request Form](https://docs.google.com/forms/d/e/1FAIpQLSe2_21Jllo8kztsnhhF_Xre9iOiPoeELUWwYziCDB25y68Wpw/viewform). Estimated delivery time will be communicated by IT once the order has been placed, but expect on average 1-4 week delivery window.
+
+We offer three desktop options. The specifications below are those we believe are needed for you to do your best work at Mattermost, but they are not a hard ceiling. If you need upgraded specifications, outline them within the [Desktop Request Form](https://docs.google.com/forms/d/e/1FAIpQLSe2_21Jllo8kztsnhhF_Xre9iOiPoeELUWwYziCDB25y68Wpw/viewform).
+
+* **Mac:**
+  * Mac Studio
+  * M1 Ultra \(20-core CPU, 48-core GPU, 32-core Neural Engine\)
+  * 64GB unified memory
+  * 1TB SSD storage
+* **Windows:**
+  * Windows 11 Pro
+  * 13th Gen Intel Core i9-13900k \(24-core, 32M Cache, 2.0 GHz to 5.2 GHz\)
+  * 32GB 4800Mhz DDR5 memory
+  * 1TB M.2 PCIe NVMe
+* **Linux:**
+  * Ubuntu 20.04
+  * Intel Xeon Silver 4216 \(16-core, 22MB Cache, 2.10 GHz to 3.20 GHz\)
+  * 32GB 2666Mhz DDR4 memory
+  * 1 TB M.2, PCIe NVMe
+
+As with other computer devices, once your desktop is received, you're required to register it by completing an [Asset Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSfesCJ-XMvXjBxeAYJxvzzbvZHnSv2rH9I48IioJrURNhd7Eg/viewform). This step should be completed within 5 business days after your desktop was received.
+
+### Other computer technology
+
+If you need a device other than a laptop or mobile phone for your role, you should have a business use reason for the device and authorization from your manager before purchasing. If both are satisfied, you can proceed with purchasing the device on your own or [open an IT ticket](https://helpdesk.mattermost.com/) and the IT team will purchase this for you.
+
+After you obtain the asset, it's necessary to register your hardware by completing the [Asset Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSfesCJ-XMvXjBxeAYJxvzzbvZHnSv2rH9I48IioJrURNhd7Eg/viewform) if any one or more of the following criteria are met:
+
+* The cost of the device is 1,000 USD or greater.
+* The device contains company data and has access to company credentials.
+* The device contains customer data, confidential company information, or personally identifiable information \(PII\).
+
+If you purchased the device on your own and you're submitting an expense report for reimbursement, attach the Asset Registration email confirmation with your expense report. This step should be completed within 5 business days after your device was received. Any registered device will need to be returned to Mattermost if you leave the company, or may be eligible to be kept if it falls under the [Hardware buyback policy](https://handbook.mattermost.com/operations/workplace/it/hardware-buy-back-policy)
+
+#### Hardware
+
+If you require a tablet or phone as part of your role, or you participate in an on-call rotation, you may be eligible for a Mattermost-provided phone. Company phones are not mandatory. Using personal phones for business is an endorsed and acceptable practice; however, if a company phone is preferred, please follow these steps:
+
+1. Get approval from your direct manager.
+2. With your manager's approval and business justification, [open a ticket](https://helpdesk.mattermost.com/) with the required device: iOS Phone/Tablet, Android Phone/Tablet, etc.
+3. A member of IT will reach out to coordinate the purchase and delivery of the requested device.
+
+**Note:** On average, devices will be 2 generations behind the newest available model. 
+
+#### Mobile device management \(MDM\)
+
+In order to protect company information, usage of a Mobile Device Management \(MDM\) solution is mandatory for a company provided phone. An MDM must not be configured when using a personal phone.
+
+When the device has been lost, the MDM solution enables the company to remotely wipe the phone to ensure protection of customer data and additionally enforce security policies on the device.
+
+#### Process
+
+Each employee can order the hardware and subscription if they're part of an eligible group. Afterwards expense it according to the current process, once for the hardware, and each month for the subscription.
+
+After the hardware is received, it's mandatory to register with our Mobile Device Management \(MDM\) provider following this process \[link pending\] and our [Asset Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSfesCJ-XMvXjBxeAYJxvzzbvZHnSv2rH9I48IioJrURNhd7Eg/viewform). This must be completed within 5 business days after the device was received.
+
+The employee is allowed to request a new mobile device every three years according to the current mobile device policy. Earlier replacement is possible if the device is damaged or otherwise prevents required business usage.
+
+When the work relationship between a staff member and the company ends the company device may be eligible to be kept under the [Hardware buy back policy](https://handbook.mattermost.com/operations/workplace/it/hardware-buy-back-policy)
+
+#### Acceptable use
+
+The company device may only be used for work-related purposes. Personal usage is explicitly discouraged outside of emergency situations. Mattermost is not responsible for any personal data loss upon a remotely-initiated device wipe.
+
+### Equipment replacement
+
+#### Laptop
+
+Many staff members will use their company issued laptop until it breaks. That said, if your productivity is suffering, you can request a new laptop at any time [here](https://docs.google.com/forms/d/e/1FAIpQLSe7DV-dt1K4G2UtVszjK78iRZD5i_ubhRk3xkUKnEemcyyELw/viewform). The average timeframe for equipment replacement is approximately three years. Old laptops fall under the [Hardware Buy Back Policy](https://handbook.mattermost.com/operations/it/hardware-buy-back-policy). Replacement laptops should follow the registration process similar to new hires by completing our [Asset Registration Form](https://docs.google.com/forms/d/e/1FAIpQLSfesCJ-XMvXjBxeAYJxvzzbvZHnSv2rH9I48IioJrURNhd7Eg/viewform).
+
+#### Other
+
+Purchase as you need. We expect *most* items to have 18 to 24 month life and would expect additional purchases.
+
+### Software systems
+
+All software should be provisioned through a corporate account. This helps mitigate multiple accounts for the same application. To see software Mattermost currently subscribes to, join the [Systems channel](https://community.mattermost.com/private-core/channels/systems) and click on **View & Request Access to Systems** in the header.
+
+If there's a piece of software you're looking to buy that Mattermost does not have a subscription to, discuss with your manager and then [Create a ticket](https://helpdesk.mattermost.com/) to discuss with IT. All committed or material subscription requests should follow the instructions to purchase by [submitting a PO](https://handbook.mattermost.com/operations/finance/purchasing/how-to-procure-a-vendor-contract).
+
+If you are seeking to test a new software and it is not a material cost or comittment \(e.g. a month-to-month cloud hosted software\), the most expedient method may be requesting a [Virtual credit card](https://handbook.mattermost.com/operations/finance/purchasing/airbase/how-to-submit-a-virtual-card-request). Reach out to the [Purchases](https://community.mattermost.com/private-core/channels/purchases) channel. Please note that IT will need to be provisioned an account to any new software solution to properly audit and administrate access.
+
+Note that any software expensed that has not been vetted through Procurement will not be reimbursed. Should you have questions, reach out to the [Purchases](https://community.mattermost.com/private-core/channels/purchases) channel.
+
+


### PR DESCRIPTION
Moving this section from the "How to spend company money" section of the handbook. Other minor updates made to reflect policy changes. Added approved vendors.

