### PR TITLE
Adding public speaking page

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -130,6 +130,7 @@
     * [Sustained Engineering](operations/research-and-development/engineering/team/README.md)
       * [On call](operations/research-and-development/engineering/team/on-call.md)
     * [How to go to a conference](operations/research-and-development/engineering/how-to-go-to-conference.md)
+    * [Public speaking](operations/research-and-development/engineering/public-speaking.md)
     * [Core contributor expanded access policy](operations/research-and-development/engineering/core-contributor-expanded-access.md)
   * [Quality Assurance](operations/research-and-development/quality/README.md)
     * [QA workflow](operations/research-and-development/quality/qa-workflow.md)

--- a/operations/research-and-development/engineering/public-speaking.md
+++ b/operations/research-and-development/engineering/public-speaking.md
@@ -1,60 +1,62 @@
 # Public Speaking
 
-In Mattermost, we encourage public speaking at any level, from small meetups to big international conferences. The DevRel team can help you with public speaking. To contact the DevRel team, enter the DevRel channel in the Mattermost server.
+At Mattermost, we encourage public speaking at all levels, from small meetups to large international conferences. The DevRel team is available to assist you with public speaking. To contact the DevRel team, join the [~DevRelOps channel](https://hub.mattermost.com/private-core/channels/devrelops) on Hub.
 
 ## How to get started
 
-We recommend contacting the DevRel team if you are interested in public speaking. We will help you start with small meetups in your city or region or go big upfront. However, you prefer. To find small meetups, we recommend you check meetups in [Meetup](https://www.meetup.com/). For more prominent conferences, you can check sites like [Papercall](https://www.papercall.io/), [Sessionize](https://sessionize.com/), or [Developers Events](https://developers.events/).
+You could start with small meetups in your city or region, or jump straight to larger events, depending on your preference. To find small meetups, we recommend checking [Meetup](https://www.meetup.com/). For larger conferences, check sites like [Papercall](https://www.papercall.io/), [Sessionize](https://sessionize.com/), or [Developers Events](https://developers.events/).
 
-Another common problem that starters face is selecting the topic and preparing the CFP (Call For Papers). We can help you with that. Contact us, and we will brainstorm to find the best topic for you and prepare the CFP.
+A common challenge for beginners is selecting a topic and preparing the CFP (Call For Papers). You can join the [~DevRelOps channel](https://hub.mattermost.com/private-core/channels/devrelops) for assistance with CFP creation.
 
-Once you have the CFP prepared, you need to prepare your slides; we can help you with that, too. We can review your slides, give you feedback, or even have a pairing session to prepare the content.
+Once your CFP is ready, you need to prepare your slides. The DevRel team can review your slides, give you feedback, or even have a working session to prepare the content.
 
-After preparing your slides, you have multiple options for rehearsing your talk. You can do it in front of some of the DevVel team or front of the company as part of the DevMeeting.
+After preparing your slides, there are multiple options for rehearsing your talk. The weekly Developers Meeting and R&D Meeting are great opportunities to practice delivering your content.
 
-Finally, whenever you get selected and have to go to the conference/meetup, we can provide you with the help you need. We can help you book the hotel and the trip (if required), and the company will cover the cost (if the conference does not cover it).
+Finally, once you are selected to attend a conference or meetup, Mattermost can provide the necessary support. Mattermost can assist with booking the hotel and transportation (if required), and the company will cover the cost (if the conference does it). For more information, see [How to spend company money](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
-## How to select the event
+## How to select an event
 
-When selecting the event you want to apply for, you need to consider the following rule: the bigger/more relevant the event, the farther you can go. Let's see some examples:
+When selecting an event to apply for, consider this rule: the bigger and more high-impact the event, the farther you can travel.
 
-  We encourage you to apply to as many small events as you want in your city or region (when no flight/hotel is needed). For example, The GoMad if you live near Madrid or DevFests near you.
-  We encourage you to apply to any medium/big event in your country. Anything with over 300 attendees can be considered a medium/big event. For example, in Spain, something like Codemotion or Commit Conf could be viewed as a medium/big event.
-  We encourage you to apply to any big/relevant event internationally. Anything with over 1000 attendees or that is a reference in the industry can be considered a big/relevant event, such as GopherCon, PgEurope, or Fosdem.
-  - If the event covers the cost of the flight and the hotel, you can go as far as you want, no matter the size of the conference.
+We encourage you to apply to as many small events as you want in your city or region (when no flight/hotel is needed). For example, a DevOpsDays near you.
 
-Also, in terms of the theme of the conferences, we focus our efforts on conferences related to Mattermost objective (mission-critical work) or technologies that we use. For instance, conferences about cybersecurity, DevOps, AI, Go, Postgres, and Kubernetes are all good options; Java or Ruby events would not be. More generalistic conferences that include relevant topics are also good.
+We encourage you to apply to any medium or large event in your country. Events with over 300 attendees are considered medium or large. For example, Codemotion or Commit Conf would be considered medium or large events in Spain.
 
-Ask the DevRel team if you are unsure if the event is big/relevant enough.
+We encourage you to apply to any major or relevant international event. Events with over 1000 attendees or those recognized as industry benchmarks are considered major or relevant, such as GopherCon, PgEurope, or FOSDEM.
 
-## Requirements about the content
+If the event covers the cost of your flight and hotel, you can attend regardless of the conference's size.
 
-In Mattermost, we don't have any restrictions about the content of the talks; you can talk about whatever you want (always being respectful). However, we encourage you to talk about the great things we do at Mattermost. Also, we encourage you to mention Mattermost during the introduction of the talk, for example, "My name is XXX, and I'm YYY at Mattermost; for whoever doesn't know, Mattermost is a communication platform for Mission Critical Infrastructure."
+Additionally, we focus on conferences related to Mattermost's objectives (mission-critical work) or the technologies we use. For instance, conferences on cybersecurity, DevOps, AI, Go, Postgres, and Kubernetes are good options, whereas Java or Ruby events are not. More general conferences that include relevant topics are also acceptable.
 
-When you are talking at a conference, you are still representing Mattermost to a certain degree, so we expect you to be respectful and professional no matter the topic that you are talking about. Also, we expect you not to share any data that can be considered private during the conferences and, of course, follow the "Code of Conduct" of the conference.
+Consult the [~DevRelOps channel](https://hub.mattermost.com/private-core/channels/devrelops) if you are unsure whether an event is significant or relevant enough.
+
+## Requirements about content
+
+At Mattermost, we don't have any restrictions on the content of your talks; you can speak about whatever you want (always being respectful). However, we encourage you to highlight the great things we do at Mattermost. Additionally, we encourage you to mention Mattermost during your introduction. For example, "My name is XXX, and I'm YYY at Mattermost. For those who don't know, Mattermost is a communication platform for mission-critical infrastructure." If you are unsure about the best way to mention Mattermost, reach out to the [~DevRelOps channel](https://hub.mattermost.com/private-core/channels/devrelops).
+
+When speaking at a conference, you represent Mattermost to a certain degree, so we expect you to be respectful and professional, regardless of your topic. We also expect you not to share any private data during conferences and, of course, to follow the conference's "Code of Conduct."
+
+After submitting a proposal to a CFP, add it to Mattermost's [thought leadership spreadsheet](https://docs.google.com/spreadsheets/d/1peej--v7WhjU58J_Wv-OW_iutT_MqqsTMMZeBS5qIBc/edit?gid=891481386#gid=891481386) for tracking. If selected, update the spreadsheet and notify the [~DevRelOps channel](https://hub.mattermost.com/private-core/channels/devrelops).
 
 ## FAQ
 
-Q: Should I take a holiday to speak at a conference?
+Q: Should I take PTO to speak at a conference?
 A: No, travel and conference days are considered work days for you.
 
-Q: Can I expense the breakfast, lunch, or dinner?
-A: If the conference already provides breakfast, lunch, or dinner, do not expense it; if not, expense it.
+Q: Can I expense breakfast, lunch, or dinner?
+A: If the conference already provides breakfast, lunch, or dinner, do not expense it. If not, follow [spending guidelines](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
-Q: Can I expense the transportation?
-A: Yes, if you need to take a taxi or any other transportation, do it like you were using your money.
+Q: Can I expense transportation?
+A: Yes, if you need to book a plane, call a rideshare, or use other transportation, follow [spending guidelines](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
-Q: Can I expense the hotel's cost?
-A: If the conference is not covering the hotel, you can expense it.
-
-Q: Can I expense the flight?
-A: If the conference does not cover the flight, you can expense it.
+Q: Can I expense lodging?
+A: If the conference is not covering the hotel, you can expense it. Follow [spending guidelines](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
 Q: Can I expense a luxury restaurant?
-A: Avoid luxury places, but any place where you would go to eat on a regular day should work. It doesn't need to be cheap.
+A: Avoid luxury places, but any place where you would go to eat on a regular day should work. It doesn't need to be cheap, but [spend company money like it's your own](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
 Q: Can I expense other things?
 A: Try to use common sense, but ask the DevRel team if you have any doubts.
 
 Q: Who has to approve my expenses?
-A: Public Speaking expenses are the responsibility of the DevRel team.
+A: Public speaking expenses should be submitted in Airbase.

--- a/operations/research-and-development/engineering/public-speaking.md
+++ b/operations/research-and-development/engineering/public-speaking.md
@@ -1,0 +1,60 @@
+# Public Speaking
+
+In Mattermost, we encourage public speaking at any level, from small meetups to big international conferences. The DevRel team can help you with public speaking. To contact the DevRel team, enter the DevRel channel in the Mattermost server.
+
+## How to get started
+
+We recommend contacting the DevRel team if you are interested in public speaking. We will help you start with small meetups in your city or region or go big upfront. However, you prefer. To find small meetups, we recommend you check meetups in [Meetup](https://www.meetup.com/). For more prominent conferences, you can check sites like [Papercall](https://www.papercall.io/), [Sessionize](https://sessionize.com/), or [Developers Events](https://developers.events/).
+
+Another common problem that starters face is selecting the topic and preparing the CFP (Call For Papers). We can help you with that. Contact us, and we will brainstorm to find the best topic for you and prepare the CFP.
+
+Once you have the CFP prepared, you need to prepare your slides; we can help you with that, too. We can review your slides, give you feedback, or even have a pairing session to prepare the content.
+
+After preparing your slides, you have multiple options for rehearsing your talk. You can do it in front of some of the DevVel team or front of the company as part of the DevMeeting.
+
+Finally, whenever you get selected and have to go to the conference/meetup, we can provide you with the help you need. We can help you book the hotel and the trip (if required), and the company will cover the cost (if the conference does not cover it).
+
+## How to select the event
+
+When selecting the event you want to apply for, you need to consider the following rule: the bigger/more relevant the event, the farther you can go. Let's see some examples:
+
+  We encourage you to apply to as many small events as you want in your city or region (when no flight/hotel is needed). For example, The GoMad if you live near Madrid or DevFests near you.
+  We encourage you to apply to any medium/big event in your country. Anything with over 300 attendees can be considered a medium/big event. For example, in Spain, something like Codemotion or Commit Conf could be viewed as a medium/big event.
+  We encourage you to apply to any big/relevant event internationally. Anything with over 1000 attendees or that is a reference in the industry can be considered a big/relevant event, such as GopherCon, PgEurope, or Fosdem.
+  - If the event covers the cost of the flight and the hotel, you can go as far as you want, no matter the size of the conference.
+
+Also, in terms of the theme of the conferences, we focus our efforts on conferences related to Mattermost objective (mission-critical work) or technologies that we use. For instance, conferences about cybersecurity, DevOps, AI, Go, Postgres, and Kubernetes are all good options; Java or Ruby events would not be. More generalistic conferences that include relevant topics are also good.
+
+Ask the DevRel team if you are unsure if the event is big/relevant enough.
+
+## Requirements about the content
+
+In Mattermost, we don't have any restrictions about the content of the talks; you can talk about whatever you want (always being respectful). However, we encourage you to talk about the great things we do at Mattermost. Also, we encourage you to mention Mattermost during the introduction of the talk, for example, "My name is XXX, and I'm YYY at Mattermost; for whoever doesn't know, Mattermost is a communication platform for Mission Critical Infrastructure."
+
+When you are talking at a conference, you are still representing Mattermost to a certain degree, so we expect you to be respectful and professional no matter the topic that you are talking about. Also, we expect you not to share any data that can be considered private during the conferences and, of course, follow the "Code of Conduct" of the conference.
+
+## FAQ
+
+Q: Should I take a holiday to speak at a conference?
+A: No, travel and conference days are considered work days for you.
+
+Q: Can I expense the breakfast, lunch, or dinner?
+A: If the conference already provides breakfast, lunch, or dinner, do not expense it; if not, expense it.
+
+Q: Can I expense the transportation?
+A: Yes, if you need to take a taxi or any other transportation, do it like you were using your money.
+
+Q: Can I expense the hotel's cost?
+A: If the conference is not covering the hotel, you can expense it.
+
+Q: Can I expense the flight?
+A: If the conference does not cover the flight, you can expense it.
+
+Q: Can I expense a luxury restaurant?
+A: Avoid luxury places, but any place where you would go to eat on a regular day should work. It doesn't need to be cheap.
+
+Q: Can I expense other things?
+A: Try to use common sense, but ask the DevRel team if you have any doubts.
+
+Q: Who has to approve my expenses?
+A: Public Speaking expenses are the responsibility of the DevRel team.

--- a/operations/research-and-development/engineering/public-speaking.md
+++ b/operations/research-and-development/engineering/public-speaking.md
@@ -12,7 +12,7 @@ Once your CFP is ready, you need to prepare your slides. The DevRel team can rev
 
 After preparing your slides, there are multiple options for rehearsing your talk. The weekly Developers Meeting and R&D Meeting are great opportunities to practice delivering your content.
 
-Finally, once you are selected to attend a conference or meetup, Mattermost can provide the necessary support. Mattermost can assist with booking the hotel and transportation (if required), and the company will cover the cost (if the conference does it). For more information, see [How to spend company money](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
+Finally, once you are selected to attend a conference or meetup, Mattermost can provide the necessary support. Mattermost can assist with booking the hotel and transportation (if required), and the company will cover the cost (if the conference doesn't cover it). For more information, see [How to spend company money](https://handbook.mattermost.com/operations/finance/staff-member-expenses/how-to-spend-company-money).
 
 ## How to select an event
 
@@ -60,3 +60,6 @@ A: Try to use common sense, but ask the DevRel team if you have any doubts.
 
 Q: Who has to approve my expenses?
 A: Public speaking expenses should be submitted in Airbase.
+
+Q: I'm a team lead, from which budget is paid the cost of public speaking for my team members?
+A: The cost of public speaking is paid from the DevRel budget.


### PR DESCRIPTION
#### Summary

This adds the page for clarifying what it means to do public speaking
for Mattermost staff.

This covers things like what I can apply for, what is covered by the
company in term of costs and what is the kind of themes and that we are
applying for.