### PR TITLE
mention BugCrowd as Bug Bounty platform

### DIFF
--- a/operations/security/product-security/product-vulnerability-process.md
+++ b/operations/security/product-security/product-vulnerability-process.md
@@ -40,7 +40,7 @@ The vulnerability has been discovered by internal security automation tools such
 The vulnerability has been reported through our [responsible disclosure program](https://mattermost.com/security-vulnerability-report/).
 
 #### Bug Bounty Program
-The vulnerability has been reported through our [Bug Bounty program running on HackerOne](https://hackerone.com/mattermost?type=team).
+The vulnerability has been reported through our [Bug Bounty program running on Bugcrowd](https://bugcrowd.com/engagements/mattermost-mbb-public).
 
 #### Customer Report
 The vulnerability has been reported from customers as part of an internal audit or on-going operations.
@@ -163,7 +163,7 @@ After confirming that the report is valid the Product Security Team member must 
 * Mattermost Team
 * Development Team
 * Playbook Run link
-* HackerOne Link
+* Bug Bounty Link
 * Affected On-Premises Versions [Text]
 * Affects Cloud [Yes/No]
 

--- a/operations/security/product-security/working-on-sensitive-prs.md
+++ b/operations/security/product-security/working-on-sensitive-prs.md
@@ -34,7 +34,7 @@ Specific words and phrases to be extra careful with:
 
  - Obvious key words: "security", "vulnerability", "exploit", "insecure", "attack".
  - Anything that identifies a vulnerability type: "XSS", "authentication bypass", "authorization bug", "SQL injection", "remote code execution", etc.
- - Security-specific tools and terminology: "HackerOne", "CVE", "CVSS", "advisory", "pentest".
+ - Security-specific tools and terminology: "HackerOne", "Bugcrowd", "CVE", "CVSS", "advisory", "pentest".
 
 ### Guidelines for developers
 


### PR DESCRIPTION
#### Summary
Updates Hackerone mentions as we transitioned to BugCrowd for a Bug Bounty program. 
