### PR TITLE
Cloud fixes don't need backporting and SLAs update

### DIFF
--- a/operations/security/product-security/product-vulnerability-process.md
+++ b/operations/security/product-security/product-vulnerability-process.md
@@ -88,7 +88,7 @@ The CVSS 3.1 provides a textural representation of the severity score in Section
 
 
 ### Remediation SLAs
-Refer to this [internal matrix](https://docs.google.com/spreadsheets/d/10XHFqy8NdbdpVNtxqz9GQL6oTlhf3jx5I3IDv9Oh-c8/edit#gid=0).
+Refer to this [internal matrix](https://mattermost.sharepoint.com/:x:/s/dept-security/EYxyAuOrTCdCiUmaeQHLQ9gBKiLLTaBE19YIXFA16KbVdw).
 
 ### Issue Types
 Vulnerabilities must be assigned one of the following vulnerability types:

--- a/operations/security/product-security/product-vulnerability-process.md
+++ b/operations/security/product-security/product-vulnerability-process.md
@@ -123,6 +123,7 @@ For Mattermost server, the following backport policy applies:
 * The Mattermost server policy also applies to vulnerabilities in bundled plugins within the respective version
 * There is no backport policy for Desktop, Mobile and standalone plugins.
 * Bundled plugins are the plugins that are pre-installed in the Mattermost server. The list of bundled plugins can be found in Mattermost server's [Makefile](https://github.com/mattermost/mattermost-server/blob/master/server/Makefile#L141). Any other plugin is considered standalone.
+* Server fixes that are specific to Mattermost Cloud do not need to be backported
 
 ## Process Steps
 


### PR DESCRIPTION
#### Summary

- Clarify that fixes specific to Mattermost Cloud do not need back porting 
- Point to latest SLAs doc on Sharepoint
