### PR TITLE
Remove remaining VPMOM references

### DIFF
--- a/operations/operations/company-cadence.md
+++ b/operations/operations/company-cadence.md
@@ -91,7 +91,7 @@ This is a bi-weekly all-staff meeting focused on increasing alignment and awaren
    * **Introduction:** One of the founders does an introduction to the meeting. Usually to align company on short and long term objectives, to reiterate larger vision for the company, or to emphasize leadership principles.
    * **Good News:** News or updates shared by team members.
    * **Week 2 Welcomes:** New team members introduced on their second week by their manager, or optionally by the new team member themselves.
-   * **Main Topics:** Align and educate team around challenges faced by Enterprise customers and around department near-term goals. Examples include: FOSDEM event highlights and learnings; Enterprise customer's path from pilot to production; department VPMOM share; key updates, use cases or stories from customers.
+   * **Main Topics:** Align and educate team around challenges faced by Enterprise customers and around department near-term goals. Examples include: FOSDEM event highlights and learnings; Enterprise customer's path from pilot to production; key updates, use cases or stories from customers.
      * Links to publicly shared documents or slides may be included in meeting notes.
    * **Feedback:** At end of meeting, conclude meeting with a reminder to share feedback via survey.
 

--- a/operations/research-and-development/product/product-roadmap-cadence.md
+++ b/operations/research-and-development/product/product-roadmap-cadence.md
@@ -6,14 +6,14 @@ Below are guidelines used to build the product release plan timeline published b
 
 ## Yearly Planning
 
-Not yet defined, as we are awaiting updates to [MLT fiscal planning](https://handbook.mattermost.com/operations/operations/mlt-cadence#fiscal-year-planning) which is currently at 1% draft. We typically use [V2MOMs](https://handbook.mattermost.com/company/how-to-guides-for-staff/how-to-vpmom) as a structure for our yearly plans.
+Not yet defined, as we are awaiting updates to [MLT fiscal planning](https://handbook.mattermost.com/operations/operations/mlt-cadence#fiscal-year-planning) which is currently at 1% draft.
 
 ## Quarterly Planning
 
 Quarterly planning involves the following:
 
 1. Research:
-   1. **Business goals** - Understand how the product \(Core, Teams, Enterprise\) can impact the Company VPMOM. Review company metrics. Identify areas we are doing well and areas we need to improve. 
+   1. **Business goals** - Understand how the product \(Core, Teams, Enterprise\) can impact the Company Priorities. Review company metrics. Identify areas we are doing well and areas we need to improve. 
    2. **Product telemetry** - Review product KPI dashboards. Identify areas we are doing well and areas we need to improve. 
    3. **Community feedback** - Overview of feedback captured in Uservoice, Jira, customer call notes, NPS surveys, app store reviews, forums etc.
    4. **Customer requests** - CS and Sales each submit a prioritized list of asks for next quarter. A call is held so PMs can understand the requests and prioritization rationale. 

--- a/operations/workplace/people/working-at-mattermost/onboarding/frequently-asked-questions.md
+++ b/operations/workplace/people/working-at-mattermost/onboarding/frequently-asked-questions.md
@@ -21,7 +21,6 @@ Please see [our guide](https://handbook.mattermost.com/company/how-to-guides-for
 ## Where can I find more information about Mattermost?
 
 * Learn more about us [here](https://mattermost.com/about-us/).
-* Check the [company VPMOMs](https://docs.google.com/document/d/1rDwcsaqQuLLDqSktV4ndlhBDCEO8JHls1sOGVKCpS4U/edit) next!
 * This handbook \(including our [“how to” guides](https://handbook.mattermost.com/company/how-to-guides-for-staff)\) is also a great resource.
 * The notes from the [Customer Obsession All-Hands](https://docs.google.com/document/d/16F86k0I_ipjhHofm5pP6yA_dWTNvmA4ZBr_z53_087Q/edit?usp=sharing) and [R&D](https://docs.google.com/document/d/1A0D96O4t4GS33-yaHvLQBdtgIScmwzVo15c2vSFeYis/edit#heading=h.3glcs57w4p51) meetings will keep you in sync. Tip: Search \#com-summary in the [COM channel](https://community.mattermost.com/private-core/channels/cust-obs-meeting) for meeting summaries by week.
 


### PR DESCRIPTION

#### Summary

There are several confusing references to VPMOM with no definition. This removes those references (where appropriate, I substituted a similar word like "Priorities".

Alternately, we could add back the VPMOM definition and background from the prior handbook - or at least add it to the List of Terms page and note that Mattermost has moved beyond that.